### PR TITLE
fix: 添加 jakarta.validation-api 依赖到 scm-common-data

### DIFF
--- a/scm-common/data/pom.xml
+++ b/scm-common/data/pom.xml
@@ -42,6 +42,12 @@
             <version>5.4.1</version>
         </dependency>
 
+        <!-- Jakarta Validation -->
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+        </dependency>
+
         <!-- spring start -->
         <!-- spring web -->
         <dependency>


### PR DESCRIPTION
## 问题

CI 编译失败，scm-common/data 中的 DTO 类使用了 jakarta.validation.constraints 注解（@NotNull、@NotBlank、@Size、@Pattern、@Email、@Min、@Max、@DecimalMin），但模块的 pom.xml 中缺少 jakarta.validation-api 依赖声明。

## 修复

在 scm-common/data/pom.xml 中添加 jakarta.validation:jakarta.validation-api 依赖。

Closes #14