### PR TITLE
feat(system): implement three-tier cache for status dict (Caffeine L1…

### DIFF
--- a/scm-system/service/src/main/java/com/scmcloud/system/cache/StatusDictCacheEventListener.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/cache/StatusDictCacheEventListener.java
@@ -1,0 +1,45 @@
+package com.scmcloud.system.cache;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * 监听状态字典变更事件，刷新本地缓存。
+ * 所有服务实例都会收到消息并清除自己的 L1 缓存。
+ *
+ * <p>事件格式: "tenantId:bizType" 或 "ALL" (全量刷新)
+ */
+@Slf4j
+@Component
+public class StatusDictCacheEventListener {
+
+    private final StatusDictCacheManager cacheManager;
+
+    public StatusDictCacheEventListener(StatusDictCacheManager cacheManager) {
+        this.cacheManager = cacheManager;
+    }
+
+    @KafkaListener(topics = "status-dict-change", groupId = "status-dict-cache")
+    public void onStatusDictChanged(ConsumerRecord<String, String> record) {
+        String payload = record.value();
+        log.info("Received status dict change event: {}", payload);
+
+        if ("ALL".equals(payload)) {
+            cacheManager.evictAll();
+            log.info("All status dict cache evicted");
+            return;
+        }
+
+        // 格式: "tenantId:bizType"
+        String[] parts = payload.split(":");
+        if (parts.length == 2) {
+            String tenantId = parts[0];
+            String bizType = parts[1];
+            cacheManager.refresh(tenantId, bizType);
+        } else {
+            log.warn("Invalid status dict change event format: {}", payload);
+        }
+    }
+}

--- a/scm-system/service/src/main/java/com/scmcloud/system/cache/StatusDictCacheManager.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/cache/StatusDictCacheManager.java
@@ -1,0 +1,317 @@
+package com.scmcloud.system.cache;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.scmcloud.common.tenant.TenantContextHolder;
+import com.scmcloud.system.domain.entity.SysStatusDict;
+import com.scmcloud.system.domain.entity.SysStatusTransition;
+import com.scmcloud.system.mapper.SysStatusDictMapper;
+import com.scmcloud.system.mapper.SysStatusTransitionMapper;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * 状态字典三级缓存管理器。
+ *
+ * <p>L1: Caffeine (JVM 内存, 5分钟 TTL)
+ * <p>L2: Redis (30分钟 TTL, key: status:dict:{tenantId}:{bizType})
+ * <p>L3: PostgreSQL (DB)
+ *
+ * <p>访问链路: Caffeine → Redis → DB → 回填
+ *
+ * <p>缓存策略:
+ * <ul>
+ *   <li>启动预热: 只加载 global (tenant_id=NULL) 数据</li>
+ *   <li>运行时: 按租户+业务类型懒加载</li>
+ *   <li>变更时: 事件驱动刷新 (Kafka)</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+public class StatusDictCacheManager {
+
+    private final SysStatusDictMapper statusDictMapper;
+    private final SysStatusTransitionMapper transitionMapper;
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // L1: Caffeine 本地缓存
+    // key = "tenantId:bizType", value = 状态字典列表
+    private final Cache<String, List<SysStatusDict>> dictCache = Caffeine.newBuilder()
+            .maximumSize(500)
+            .expireAfterWrite(Duration.ofMinutes(5))
+            .recordStats()
+            .build();
+
+    // key = "tenantId:bizType", value = 流转规则列表
+    private final Cache<String, List<SysStatusTransition>> transitionCache = Caffeine.newBuilder()
+            .maximumSize(500)
+            .expireAfterWrite(Duration.ofMinutes(5))
+            .recordStats()
+            .build();
+
+    // Redis key 前缀
+    private static final String REDIS_DICT_PREFIX = "status:dict:";
+    private static final String REDIS_TRANSITION_PREFIX = "status:transition:";
+    private static final Duration REDIS_TTL = Duration.ofMinutes(30);
+
+    public StatusDictCacheManager(SysStatusDictMapper statusDictMapper,
+                                   SysStatusTransitionMapper transitionMapper,
+                                   StringRedisTemplate redisTemplate,
+                                   ObjectMapper objectMapper) {
+        this.statusDictMapper = statusDictMapper;
+        this.transitionMapper = transitionMapper;
+        this.redisTemplate = redisTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    // ─── 状态字典缓存 ─────────────────────────────────────────
+
+    /**
+     * 获取状态字典列表 (三级缓存)
+     */
+    public List<SysStatusDict> getStatusDict(String bizType) {
+        String tenantId = resolveTenantId();
+        String cacheKey = tenantId + ":" + bizType;
+
+        // L1: Caffeine
+        List<SysStatusDict> result = dictCache.getIfPresent(cacheKey);
+        if (result != null) {
+            log.trace("Cache HIT L1: status:dict:{}", cacheKey);
+            return result;
+        }
+
+        // L2: Redis
+        result = loadDictFromRedis(tenantId, bizType);
+        if (result != null) {
+            dictCache.put(cacheKey, result);
+            log.trace("Cache HIT L2 (Redis): status:dict:{}", cacheKey);
+            return result;
+        }
+
+        // L3: DB → 回填
+        result = loadDictFromDb(tenantId, bizType);
+        saveDictToRedis(tenantId, bizType, result);
+        dictCache.put(cacheKey, result);
+        log.debug("Cache MISS → DB loaded: status:dict:{}, size={}", cacheKey, result.size());
+        return result;
+    }
+
+    /**
+     * 获取单个状态定义
+     */
+    public SysStatusDict getStatusByCode(String bizType, String statusCode) {
+        return getStatusDict(bizType).stream()
+                .filter(s -> s.getStatusCode().equals(statusCode))
+                .findFirst()
+                .orElse(null);
+    }
+
+    // ─── 流转规则缓存 ─────────────────────────────────────────
+
+    /**
+     * 获取流转规则列表 (三级缓存)
+     */
+    public List<SysStatusTransition> getTransitions(String bizType) {
+        String tenantId = resolveTenantId();
+        String cacheKey = tenantId + ":" + bizType;
+
+        // L1: Caffeine
+        List<SysStatusTransition> result = transitionCache.getIfPresent(cacheKey);
+        if (result != null) {
+            log.trace("Cache HIT L1: status:transition:{}", cacheKey);
+            return result;
+        }
+
+        // L2: Redis
+        result = loadTransitionFromRedis(tenantId, bizType);
+        if (result != null) {
+            transitionCache.put(cacheKey, result);
+            log.trace("Cache HIT L2 (Redis): status:transition:{}", cacheKey);
+            return result;
+        }
+
+        // L3: DB → 回填
+        result = loadTransitionFromDb(tenantId, bizType);
+        saveTransitionToRedis(tenantId, bizType, result);
+        transitionCache.put(cacheKey, result);
+        log.debug("Cache MISS → DB loaded: status:transition:{}, size={}", cacheKey, result.size());
+        return result;
+    }
+
+    /**
+     * 获取从某个状态出发的流转规则
+     */
+    public List<SysStatusTransition> getTransitionsFrom(String bizType, String fromStatus) {
+        return getTransitions(bizType).stream()
+                .filter(t -> t.getFromStatus().equals(fromStatus))
+                .toList();
+    }
+
+    // ─── 缓存刷新 ─────────────────────────────────────────
+
+    /**
+     * 刷新指定租户+业务类型的缓存 (DB → Redis → Caffeine)
+     */
+    public void refresh(String tenantId, String bizType) {
+        String cacheKey = tenantId + ":" + bizType;
+
+        // 重新加载
+        List<SysStatusDict> dicts = loadDictFromDb(tenantId, bizType);
+        List<SysStatusTransition> transitions = loadTransitionFromDb(tenantId, bizType);
+
+        // 写入 Redis
+        saveDictToRedis(tenantId, bizType, dicts);
+        saveTransitionToRedis(tenantId, bizType, transitions);
+
+        // 写入 Caffeine
+        dictCache.put(cacheKey, dicts);
+        transitionCache.put(cacheKey, transitions);
+
+        log.info("Cache refreshed: tenantId={}, bizType={}, dicts={}, transitions={}",
+                tenantId, bizType, dicts.size(), transitions.size());
+    }
+
+    /**
+     * 刷新全局缓存 (tenant_id=NULL)
+     */
+    public void refreshGlobal(String bizType) {
+        refresh("global", bizType);
+    }
+
+    /**
+     * 清除所有缓存 (L1 + L2)
+     */
+    public void evictAll() {
+        dictCache.invalidateAll();
+        transitionCache.invalidateAll();
+        // 注意: 不清除 Redis，让 TTL 自然过期
+        log.info("L1 cache evicted all");
+    }
+
+    /**
+     * 清除指定租户+业务类型的缓存
+     */
+    public void evict(String tenantId, String bizType) {
+        String cacheKey = tenantId + ":" + bizType;
+        dictCache.invalidate(cacheKey);
+        transitionCache.invalidate(cacheKey);
+        log.debug("L1 cache evicted: {}", cacheKey);
+    }
+
+    // ─── 启动预热 ─────────────────────────────────────────
+
+    /**
+     * 启动预热: 只加载 global (tenant_id=NULL) 数据到 L1 + L2
+     * 调用时机: ApplicationReadyEvent
+     */
+    public void prewarmGlobal() {
+        log.info("[CacheWarming] Pre-warming global status dict...");
+        long start = System.currentTimeMillis();
+
+        List<String> bizTypes = List.of("ORDER", "PURCHASE", "PURCHASE_REQUEST",
+                "INBOUND", "OUTBOUND", "APPROVAL", "LOGISTICS");
+
+        for (String bizType : bizTypes) {
+            try {
+                refresh("global", bizType);
+            } catch (Exception e) {
+                log.warn("[CacheWarming] Failed to pre-warm {}: {}", bizType, e.getMessage());
+            }
+        }
+
+        long elapsed = System.currentTimeMillis() - start;
+        log.info("[CacheWarming] Global status dict pre-warmed in {}ms", elapsed);
+    }
+
+    // ─── 内部方法 ─────────────────────────────────────────
+
+    private String resolveTenantId() {
+        var tenantId = TenantContextHolder.getTenantId();
+        return tenantId != null ? tenantId.toString() : "global";
+    }
+
+    private List<SysStatusDict> loadDictFromDb(String tenantId, String bizType) {
+        LambdaQueryWrapper<SysStatusDict> wrapper = new LambdaQueryWrapper<SysStatusDict>()
+                .eq(SysStatusDict::getBizType, bizType)
+                .eq(SysStatusDict::getDeleted, false)
+                .and(w -> w.isNull(SysStatusDict::getTenantId)
+                        .or()
+                        .eq(SysStatusDict::getTenantId, parseUuid(tenantId)))
+                .orderByAsc(SysStatusDict::getSortOrder);
+        return statusDictMapper.selectList(wrapper);
+    }
+
+    private List<SysStatusTransition> loadTransitionFromDb(String tenantId, String bizType) {
+        LambdaQueryWrapper<SysStatusTransition> wrapper = new LambdaQueryWrapper<SysStatusTransition>()
+                .eq(SysStatusTransition::getBizType, bizType)
+                .eq(SysStatusTransition::getDeleted, false)
+                .and(w -> w.isNull(SysStatusTransition::getTenantId)
+                        .or()
+                        .eq(SysStatusTransition::getTenantId, parseUuid(tenantId)))
+                .orderByAsc(SysStatusTransition::getSortOrder);
+        return transitionMapper.selectList(wrapper);
+    }
+
+    // ─── Redis 操作 ─────────────────────────────────────────
+
+    private List<SysStatusDict> loadDictFromRedis(String tenantId, String bizType) {
+        try {
+            String key = REDIS_DICT_PREFIX + tenantId + ":" + bizType;
+            String json = redisTemplate.opsForValue().get(key);
+            if (json == null) return null;
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            log.warn("Redis read failed for status:dict:{}:{}", tenantId, bizType, e);
+            return null;
+        }
+    }
+
+    private void saveDictToRedis(String tenantId, String bizType, List<SysStatusDict> data) {
+        try {
+            String key = REDIS_DICT_PREFIX + tenantId + ":" + bizType;
+            String json = objectMapper.writeValueAsString(data);
+            redisTemplate.opsForValue().set(key, json, REDIS_TTL);
+        } catch (Exception e) {
+            log.warn("Redis write failed for status:dict:{}:{}", tenantId, bizType, e);
+        }
+    }
+
+    private List<SysStatusTransition> loadTransitionFromRedis(String tenantId, String bizType) {
+        try {
+            String key = REDIS_TRANSITION_PREFIX + tenantId + ":" + bizType;
+            String json = redisTemplate.opsForValue().get(key);
+            if (json == null) return null;
+            return objectMapper.readValue(json, new TypeReference<>() {});
+        } catch (Exception e) {
+            log.warn("Redis read failed for status:transition:{}:{}", tenantId, bizType, e);
+            return null;
+        }
+    }
+
+    private void saveTransitionToRedis(String tenantId, String bizType, List<SysStatusTransition> data) {
+        try {
+            String key = REDIS_TRANSITION_PREFIX + tenantId + ":" + bizType;
+            String json = objectMapper.writeValueAsString(data);
+            redisTemplate.opsForValue().set(key, json, REDIS_TTL);
+        } catch (Exception e) {
+            log.warn("Redis write failed for status:transition:{}:{}", tenantId, bizType, e);
+        }
+    }
+
+    private java.util.UUID parseUuid(String str) {
+        if (str == null || "global".equals(str)) return null;
+        try { return java.util.UUID.fromString(str); } catch (Exception e) { return null; }
+    }
+}

--- a/scm-system/service/src/main/java/com/scmcloud/system/cache/StatusDictCacheWarmer.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/cache/StatusDictCacheWarmer.java
@@ -1,0 +1,26 @@
+package com.scmcloud.system.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 状态字典启动预热器。
+ * 只加载 global (tenant_id=NULL) 数据，不做全租户预热。
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StatusDictCacheWarmer {
+
+    private final StatusDictCacheManager cacheManager;
+
+    @EventListener(ApplicationReadyEvent.class)
+    @Order(10)
+    public void onStartup() {
+        cacheManager.prewarmGlobal();
+    }
+}

--- a/scm-system/service/src/main/java/com/scmcloud/system/cache/StatusDictEventPublisher.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/cache/StatusDictEventPublisher.java
@@ -1,0 +1,37 @@
+package com.scmcloud.system.cache;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * 状态字典变更事件发布器。
+ * 当管理员修改状态字典/流转规则时，发送 Kafka 事件通知所有服务刷新缓存。
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StatusDictEventPublisher {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    private static final String TOPIC = "status-dict-change";
+
+    /**
+     * 通知指定租户+业务类型的缓存需要刷新
+     */
+    public void publishChange(String tenantId, String bizType) {
+        String payload = tenantId + ":" + bizType;
+        kafkaTemplate.send(TOPIC, bizType, payload);
+        log.info("Published status dict change: {}", payload);
+    }
+
+    /**
+     * 通知全量缓存刷新
+     */
+    public void publishRefreshAll() {
+        kafkaTemplate.send(TOPIC, "ALL", "ALL");
+        log.info("Published status dict refresh ALL");
+    }
+}

--- a/scm-system/service/src/main/java/com/scmcloud/system/service/Impl/SysStatusDictServiceImpl.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/service/Impl/SysStatusDictServiceImpl.java
@@ -1,6 +1,8 @@
 package com.scmcloud.system.service.Impl;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.scmcloud.system.cache.StatusDictCacheManager;
+import com.scmcloud.system.cache.StatusDictEventPublisher;
 import com.scmcloud.system.domain.entity.SysStatusDict;
 import com.scmcloud.system.domain.entity.SysStatusTransition;
 import com.scmcloud.system.mapper.SysStatusDictMapper;
@@ -17,93 +19,96 @@ public class SysStatusDictServiceImpl implements ISysStatusDictService {
 
     private final SysStatusDictMapper statusDictMapper;
     private final SysStatusTransitionMapper transitionMapper;
+    private final StatusDictCacheManager cacheManager;
+    private final StatusDictEventPublisher eventPublisher;
+
+    // ─── 状态字典查询 (走缓存) ─────────────────────────────────
 
     @Override
     public List<SysStatusDict> listStatusDict(String bizType) {
-        LambdaQueryWrapper<SysStatusDict> wrapper = new LambdaQueryWrapper<SysStatusDict>()
-                .eq(SysStatusDict::getBizType, bizType)
-                .eq(SysStatusDict::getDeleted, false)
-                .orderByAsc(SysStatusDict::getSortOrder);
-        return statusDictMapper.selectList(wrapper);
+        return cacheManager.getStatusDict(bizType);
     }
 
     @Override
     public SysStatusDict getStatusByCode(String bizType, String statusCode) {
-        LambdaQueryWrapper<SysStatusDict> wrapper = new LambdaQueryWrapper<SysStatusDict>()
-                .eq(SysStatusDict::getBizType, bizType)
-                .eq(SysStatusDict::getStatusCode, statusCode)
-                .eq(SysStatusDict::getDeleted, false);
-        return statusDictMapper.selectOne(wrapper);
+        return cacheManager.getStatusByCode(bizType, statusCode);
     }
+
+    // ─── 状态字典变更 (写 DB + 发事件刷新缓存) ─────────────────
 
     @Override
     public void createStatusDict(SysStatusDict entity) {
         statusDictMapper.insert(entity);
+        eventPublisher.publishChange(resolveTenantId(entity.getTenantId()), entity.getBizType());
     }
 
     @Override
     public void updateStatusDict(SysStatusDict entity) {
         statusDictMapper.updateById(entity);
+        eventPublisher.publishChange(resolveTenantId(entity.getTenantId()), entity.getBizType());
     }
 
     @Override
     public void deleteStatusDict(String id) {
+        SysStatusDict existing = statusDictMapper.selectById(id);
         statusDictMapper.deleteById(id);
+        if (existing != null) {
+            eventPublisher.publishChange(resolveTenantId(existing.getTenantId()), existing.getBizType());
+        }
     }
+
+    // ─── 流转规则查询 (走缓存) ─────────────────────────────────
 
     @Override
     public List<SysStatusTransition> listTransitions(String bizType) {
-        LambdaQueryWrapper<SysStatusTransition> wrapper = new LambdaQueryWrapper<SysStatusTransition>()
-                .eq(SysStatusTransition::getBizType, bizType)
-                .eq(SysStatusTransition::getDeleted, false)
-                .orderByAsc(SysStatusTransition::getSortOrder);
-        return transitionMapper.selectList(wrapper);
+        return cacheManager.getTransitions(bizType);
     }
 
     @Override
     public List<SysStatusTransition> listTransitionsFrom(String bizType, String fromStatus) {
-        LambdaQueryWrapper<SysStatusTransition> wrapper = new LambdaQueryWrapper<SysStatusTransition>()
-                .eq(SysStatusTransition::getBizType, bizType)
-                .eq(SysStatusTransition::getFromStatus, fromStatus)
-                .eq(SysStatusTransition::getDeleted, false)
-                .orderByAsc(SysStatusTransition::getSortOrder);
-        return transitionMapper.selectList(wrapper);
+        return cacheManager.getTransitionsFrom(bizType, fromStatus);
     }
 
     @Override
     public boolean canTransition(String bizType, String fromStatus, String toStatus) {
-        LambdaQueryWrapper<SysStatusTransition> wrapper = new LambdaQueryWrapper<SysStatusTransition>()
-                .eq(SysStatusTransition::getBizType, bizType)
-                .eq(SysStatusTransition::getFromStatus, fromStatus)
-                .eq(SysStatusTransition::getToStatus, toStatus)
-                .eq(SysStatusTransition::getEnabled, true)
-                .eq(SysStatusTransition::getDeleted, false);
-        return transitionMapper.selectCount(wrapper) > 0;
+        return cacheManager.getTransitionsFrom(bizType, fromStatus).stream()
+                .anyMatch(t -> t.getToStatus().equals(toStatus) && t.getEnabled());
     }
 
     @Override
     public SysStatusTransition findTransition(String bizType, String fromStatus, String toStatus, String actionCode) {
-        LambdaQueryWrapper<SysStatusTransition> wrapper = new LambdaQueryWrapper<SysStatusTransition>()
-                .eq(SysStatusTransition::getBizType, bizType)
-                .eq(SysStatusTransition::getFromStatus, fromStatus)
-                .eq(SysStatusTransition::getToStatus, toStatus)
-                .eq(SysStatusTransition::getActionCode, actionCode)
-                .eq(SysStatusTransition::getDeleted, false);
-        return transitionMapper.selectOne(wrapper);
+        return cacheManager.getTransitionsFrom(bizType, fromStatus).stream()
+                .filter(t -> t.getToStatus().equals(toStatus)
+                        && t.getActionCode().equals(actionCode)
+                        && t.getEnabled())
+                .findFirst()
+                .orElse(null);
     }
+
+    // ─── 流转规则变更 (写 DB + 发事件刷新缓存) ─────────────────
 
     @Override
     public void createTransition(SysStatusTransition entity) {
         transitionMapper.insert(entity);
+        eventPublisher.publishChange(resolveTenantId(entity.getTenantId()), entity.getBizType());
     }
 
     @Override
     public void updateTransition(SysStatusTransition entity) {
         transitionMapper.updateById(entity);
+        eventPublisher.publishChange(resolveTenantId(entity.getTenantId()), entity.getBizType());
     }
 
     @Override
     public void deleteTransition(String id) {
+        SysStatusTransition existing = transitionMapper.selectById(id);
         transitionMapper.deleteById(id);
+        if (existing != null) {
+            eventPublisher.publishChange(resolveTenantId(existing.getTenantId()), existing.getBizType());
+        }
+    }
+
+    private String resolveTenantId(String tenantId) {
+        return tenantId != null ? tenantId : "global";
     }
 }


### PR DESCRIPTION
… + Redis L2 + DB L3) with Kafka event refresh

## 变更说明

<!-- 简要描述本次变更的内容 -->

## 关联 Issue

<!-- 使用 Closes #xxx 关闭 Issue,或 Refs #xxx 仅引用 -->
Closes #

## 影响模块

<!-- 列出本次变更涉及的模块 -->
- [ ] scm-common
- [ ] scm-auth
- [ ] scm-order
- [ ] scm-inventory
- [ ] scm-product
- [ ] scm-warehouse
- [ ] scm-logistics
- [ ] scm-supplier
- [ ] scm-purchase
- [ ] scm-finance
- [ ] scm-gateway
- [ ] scm-system
- [ ] scm-tenant
- [ ] scm-approval
- [ ] scm-audit
- [ ] scm-notify

## 测试说明

<!-- 描述如何验证这些改动 -->

## 测试覆盖率

<!-- 当前测试覆盖率: __% -->

## 截图/演示

<!-- 如涉及UI变更,请附上截图 -->

## Checklist

- [ ] 代码已通过本地构建 (`mvn clean verify`)
- [ ] 测试覆盖率 ≥ 80% (关键模块 ≥ 90%)
- [ ] 无 Checkstyle/SpotBugs 严重问题
- [ ] 无敏感信息泄露
- [ ] 已更新相关文档
