### PR TITLE
fix: add testcontainers dependency to scm-common/core for CI

### DIFF
--- a/com.scm.parent/pom.xml
+++ b/com.scm.parent/pom.xml
@@ -84,6 +84,9 @@
     <!-- Messaging -->
     <rabbitmq.version>5.14.2</rabbitmq.version>
 
+    <!-- Testcontainers -->
+    <testcontainers.version>1.20.6</testcontainers.version>
+
     <!-- Observability -->
     <sentinel.version>2025.0.0.0</sentinel.version>
     <sentinel-datasource-nacos.version>1.8.7</sentinel-datasource-nacos.version>
@@ -362,6 +365,17 @@
         <groupId>io.micrometer</groupId>
         <artifactId>micrometer-registry-prometheus</artifactId>
         <version>${micrometer.version}</version>
+      </dependency>
+
+      <!-- ==================== Testing ==================== -->
+
+      <!-- Testcontainers BOM for version management -->
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
     </dependencies>

--- a/scm-common/core/pom.xml
+++ b/scm-common/core/pom.xml
@@ -86,5 +86,20 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>kafka</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## 修复

\scm-common/core\ 的 \AbstractIntegrationTest.java\ 使用 Testcontainers 但缺少依赖，导致 CI 编译失败。

## 变更

- 父 POM：添加 \	estcontainers.version\ (1.20.6)、导入 \	estcontainers-bom\
- \scm-common/core/pom.xml\：添加 \	estcontainers\、\postgresql\、\kafka\ 依赖（test scope）

## 关联 Issue

Closes #51