### PR TITLE
fix: update ApiSignatureFilterTest for Spring Boot 4.x mock API

### DIFF
--- a/scm-gateway/src/test/java/com/scmcloud/gateway/filter/ApiSignatureFilterTest.java
+++ b/scm-gateway/src/test/java/com/scmcloud/gateway/filter/ApiSignatureFilterTest.java
@@ -146,13 +146,15 @@ class ApiSignatureFilterTest {
 
     private MockServerWebExchange signedExchange(String path, String body, String appId, String nonce, String timestamp) {
         byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
-        MockServerHttpRequest unsigned = MockServerHttpRequest.post(path)
-                .header("X-App-Id", appId)
-                .header("X-Timestamp", timestamp)
-                .header("X-Nonce", nonce)
-                .header("X-Sign-Version", properties.getDefaultVersion())
-                .body(bodyBytes);
-        ServerHttpRequest requestForSignature = new CachedBodyRequestDecorator(unsigned, bodyBytes);
+
+        ServerHttpRequest requestForSignature = new CachedBodyRequestDecorator(
+                MockServerHttpRequest.post(path)
+                        .header("X-App-Id", appId)
+                        .header("X-Timestamp", timestamp)
+                        .header("X-Nonce", nonce)
+                        .header("X-Sign-Version", properties.getDefaultVersion())
+                        .body(body),
+                bodyBytes);
 
         String signature = registry.getAlgorithm(properties.getDefaultVersion())
                 .calculate(requestForSignature, appId, timestamp, nonce, properties.getAppSecrets().get(appId))
@@ -164,9 +166,9 @@ class ApiSignatureFilterTest {
                 .header("X-Nonce", nonce)
                 .header("X-Sign-Version", properties.getDefaultVersion())
                 .header("X-Signature", signature)
-                .body(bodyBytes);
-        ServerHttpRequest decorated = new CachedBodyRequestDecorator(signed, bodyBytes);
-        return MockServerWebExchange.from(decorated);
+                .body(body);
+
+        return MockServerWebExchange.from(signed);
     }
 
     private String responseBody(MockServerWebExchange exchange) {


### PR DESCRIPTION
## 修复

ApiSignatureFilterTest 使用已废弃/不存在的 mock API，修复：
- body(byte[]) → body(String)（byte[] 重载在 SB4 中移除）
- 不在 MockServerWebExchange.from() 中传入装饰请求（ServerHttpRequest 不被接受）

## 关联 Issue

Closes #57