### PR TITLE
fix: remove StatusValidator from maven-compiler excludes list

### DIFF
--- a/scm-audit/service/src/main/java/com/scmcloud/audit/aspect/SysAuditLogAspect.java
+++ b/scm-audit/service/src/main/java/com/scmcloud/audit/aspect/SysAuditLogAspect.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scmcloud.audit.domain.entity.SysAuditLog;
 import com.scmcloud.audit.mapper.SysAuditLogMapper;
 import com.scmcloud.common.log.annotation.AuditLog;
-import com.scmcloud.common.status.StatusValidator;
 import com.scmcloud.common.security.util.DesensitizeUtils;
 import com.scmcloud.common.security.util.IpUtils;
 import com.scmcloud.common.web.util.SecurityUtils;
@@ -29,7 +28,6 @@ import java.util.UUID;
 public class SysAuditLogAspect {
     private final SysAuditLogMapper sysAuditLogMapper;
     private final ObjectMapper objectMapper;
-    private final StatusValidator statusValidator;
 
     @Around("@annotation(com.scmcloud.common.log.annotation.AuditLog)")
     public Object around(ProceedingJoinPoint point) throws Throwable {

--- a/scm-common/web/pom.xml
+++ b/scm-common/web/pom.xml
@@ -32,7 +32,7 @@
                         <exclude>**/DynamicPermissionLoader.java</exclude>
                         <exclude>**/FeignPermissionAccess.java</exclude>
                         <exclude>**/RestClientHttpExchangeConfig.java</exclude>
-                        <exclude>**/StatusValidator.java</exclude>
+
                         <exclude>**/CustomUserDetailsService.java</exclude>
                     </excludes>
                     <testExcludes>


### PR DESCRIPTION
## 修复

scm-common/web/pom.xml 的 maven-compiler-plugin 排除了 **/StatusValidator.java，移除该排除项。同时清理 SysAuditLogAspect 中未使用的 statusValidator 字段。

## 关联 Issue

Closes #61