### PR TITLE
fix: resolveTenantId accepts UUID instead of String to match entity getter type

### DIFF
--- a/scm-system/service/src/main/java/com/scmcloud/system/service/Impl/SysStatusDictServiceImpl.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/service/Impl/SysStatusDictServiceImpl.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -108,7 +109,7 @@ public class SysStatusDictServiceImpl implements ISysStatusDictService {
         }
     }
 
-    private String resolveTenantId(String tenantId) {
-        return tenantId != null ? tenantId : "global";
+    private String resolveTenantId(UUID tenantId) {
+        return tenantId != null ? tenantId.toString() : "global";
     }
 }


### PR DESCRIPTION
## 修复

resolveTenantId 参数从 String 改为 UUID，内部调用 toString() 转换。

## 关联 Issue

Closes #67