### PR TITLE
fix: ApiResponse.fail takes (int code, String message), not single String

### DIFF
--- a/scm-tenant/service/src/main/java/com/scmcloud/tenant/controller/TenantProvisioningController.java
+++ b/scm-tenant/service/src/main/java/com/scmcloud/tenant/controller/TenantProvisioningController.java
@@ -24,7 +24,7 @@ public class TenantProvisioningController {
         if (result.isSuccess()) {
             return ApiResponse.success(result);
         } else {
-            return ApiResponse.fail(result.getErrorMessage());
+            return ApiResponse.fail(500, result.getErrorMessage());
         }
     }
 }


### PR DESCRIPTION
## 修复

ApiResponse 没有 fail(String) 重载，只有 fail(int, String) 和 fail(ResultCode)。
改为 fail(500, errorMessage)。

## 关联 Issue

Closes #69