### PR TITLE
fix: unclosed string literal in FrogTest due to corrupted Chinese characters

### DIFF
--- a/scm-auth/src/test/java/com/scmcloud/test/FrogTest.java
+++ b/scm-auth/src/test/java/com/scmcloud/test/FrogTest.java
@@ -43,7 +43,7 @@ public class FrogTest {
     @Test
     public void testAnotherExample() {
         String str = "Frog";
-        assertEquals("Frog", str, "字符串应该相�);
+        assertEquals("Frog", str, "strings should be equal");
         System.out.println("str = " + str);
     }
 


### PR DESCRIPTION
## 修复

FrogTest.java 第46行中文被编码破坏导致字符串字面量未闭合，改为英文。

Closes #71