### PR TITLE
fix: add missing jackson-databind dependency to scm-order-api

### DIFF
--- a/scm-order/api/pom.xml
+++ b/scm-order/api/pom.xml
@@ -22,6 +22,10 @@
             <artifactId>lombok</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
## 修复

scm-order-api/pom.xml 缺少 jackson-databind 依赖，导致 OrderVO.java 中的 @JsonSerialize/ToStringSerializer 编译失败。

Closes #73