### PR TITLE
fix: update tests and service to match current PermissionDTO and UserCrossDatabaseQueryService API

### DIFF
--- a/scm-system/service/src/main/java/com/scmcloud/system/service/query/UserCrossDatabaseQueryService.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/service/query/UserCrossDatabaseQueryService.java
@@ -269,6 +269,44 @@ public class UserCrossDatabaseQueryService {
         return getCountOrDefault(userId, uid -> userRoleMapper.countExpiringRoles(uid, days));
     }
 
+    /**
+     * 统计指定部门的用户数
+     *
+     * @param deptId 部门 ID
+     * @return 用户数
+     */
+    @Slave
+    public int countUsersByDeptId(UUID deptId) {
+        if (deptId == null) {
+            return 0;
+        }
+        Integer count = userMapper.countUsersByDeptId(deptId);
+        return count != null ? count : 0;
+    }
+
+    /**
+     * 批量统计指定部门的用户数
+     *
+     * @param deptIds 部门 ID 列表
+     * @return 部门 ID -> 用户数 映射
+     */
+    @Slave
+    public Map<UUID, Integer> countUsersByDeptIds(List<UUID> deptIds) {
+        if (deptIds == null || deptIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+        Map<UUID, Map<String, Object>> raw = userMapper.countUsersByDeptIds(deptIds);
+        if (raw == null) {
+            return Collections.emptyMap();
+        }
+        Map<UUID, Integer> result = new HashMap<>();
+        for (Map.Entry<UUID, Map<String, Object>> entry : raw.entrySet()) {
+            Object count = entry.getValue().get("user_count");
+            result.put(entry.getKey(), count instanceof Number ? ((Number) count).intValue() : 0);
+        }
+        return result;
+    }
+
     // ==================== 私有辅助方法 ====================
 
     /**

--- a/scm-system/service/src/test/java/com/scmcloud/system/service/query/PermissionCrossDatabaseQueryServiceTest.java
+++ b/scm-system/service/src/test/java/com/scmcloud/system/service/query/PermissionCrossDatabaseQueryServiceTest.java
@@ -44,7 +44,7 @@ class PermissionCrossDatabaseQueryServiceTest {
         testPermission.setPermissionName("User Management");
         testPermission.setPermissionCode("user:manage");
         testPermission.setPermissionType(1); // Menu
-        testPermission.setPath("/user");
+        testPermission.setRoutePath("/user");
         testPermission.setComponent("User");
         testPermission.setIcon("user");
         testPermission.setSortOrder(1);
@@ -71,7 +71,7 @@ class PermissionCrossDatabaseQueryServiceTest {
         assertEquals(testPermissionId, menu.getId());
         assertEquals("User Management", menu.getPermissionName());
         assertEquals("user:manage", menu.getPermissionCode());
-        assertEquals("/user", menu.getPath());
+        assertEquals("/user", menu.getRoutePath());
         verify(permissionMapper).findMenuTreeByUserId(testUserId);
     }
 
@@ -298,16 +298,13 @@ class PermissionCrossDatabaseQueryServiceTest {
         completeMenu.setPermissionName("Complete Menu");
         completeMenu.setPermissionCode("complete:menu");
         completeMenu.setPermissionType(1);
-        completeMenu.setPath("/complete");
+        completeMenu.setRoutePath("/complete");
         completeMenu.setComponent("Complete");
         completeMenu.setIcon("complete-icon");
         completeMenu.setRedirect("/complete/index");
-        completeMenu.setIsVisible(true);
-        completeMenu.setIsCache(true);
-        completeMenu.setIsFrame(false);
+        completeMenu.setVisible(true);
         completeMenu.setSortOrder(1);
         completeMenu.setStatus(1);
-        completeMenu.setRemark("Test menu");
 
         List<PermissionDTO> expectedMenus = Collections.singletonList(completeMenu);
         when(permissionMapper.findMenuTreeByUserId(testUserId)).thenReturn(expectedMenus);
@@ -323,7 +320,7 @@ class PermissionCrossDatabaseQueryServiceTest {
         assertEquals(testPermissionId, resultMenu.getId());
         assertEquals("Complete Menu", resultMenu.getPermissionName());
         assertEquals("complete:menu", resultMenu.getPermissionCode());
-        assertEquals("/complete", resultMenu.getPath());
+        assertEquals("/complete", resultMenu.getRoutePath());
         assertEquals("Complete", resultMenu.getComponent());
         assertEquals("complete-icon", resultMenu.getIcon());
         assertEquals(1, resultMenu.getPermissionType());


### PR DESCRIPTION
## 修复

1. PermissionCrossDatabaseQueryServiceTest: setPath → setRoutePath, getPath → getRoutePath, removed non-existent setIsVisible/setIsCache/setIsFrame/setRemark
2. UserCrossDatabaseQueryService: added countUsersByDeptId and countUsersByDeptIds methods

Closes #77