### PR TITLE
fix: missing test dependency scm-inventory-service and AbstractIntegrationTest not found

### DIFF
--- a/scm-order/service/pom.xml
+++ b/scm-order/service/pom.xml
@@ -89,6 +89,13 @@
         </dependency>
 
         <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-inventory-service</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/scm-order/service/src/test/java/com/scmcloud/order/OrderLifecycleIntegrationTest.java
+++ b/scm-order/service/src/test/java/com/scmcloud/order/OrderLifecycleIntegrationTest.java
@@ -3,9 +3,10 @@ package com.scmcloud.order;
 import com.scmcloud.order.domain.entity.OrdOrder;
 import com.scmcloud.order.domain.entity.OrderStatus;
 import com.scmcloud.order.domain.repository.OrdOrderRepository;
-import com.scmcloud.test.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
@@ -16,7 +17,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * Integration test for full order lifecycle.
  * Tests the order aggregate with real database.
  */
-class OrderLifecycleIntegrationTest extends AbstractIntegrationTest {
+@SpringBootTest
+@ActiveProfiles("test")
+class OrderLifecycleIntegrationTest {
 
     @Autowired
     private OrdOrderRepository orderRepository;


### PR DESCRIPTION
Closes #85

Two compilation errors fixed:
1. Added scm-inventory-service as test dependency in scm-order-service/pom.xml (needed for Inventory, InvInventoryMapper, etc.)
2. Removed extends AbstractIntegrationTest from OrderLifecycleIntegrationTest — added @SpringBootTest and @ActiveProfiles directly instead