### PR TITLE
fix: scm-inventory-service spring-boot-maven-plugin hides classes from dependents

### DIFF
--- a/scm-inventory/service/pom.xml
+++ b/scm-inventory/service/pom.xml
@@ -84,7 +84,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <skip>false</skip>
+                    <classifier>exec</classifier>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Closes #87

## Root cause
spring-boot-maven-plugin with skip=false repackages the JAR, moving all classes under BOOT-INF/classes/. Modules depending on scm-inventory-service (like scm-order-service tests) cannot find its classes.

## Fix
Replaced skip=false with classifier=exec, so the executable JAR gets the -exec suffix while the regular JAR remains accessible for dependency resolution.