### PR TITLE
fix: correct class names and imports in order service tests

### DIFF
--- a/scm-order/service/src/test/java/com/scmcloud/order/PerformanceTest.java
+++ b/scm-order/service/src/test/java/com/scmcloud/order/PerformanceTest.java
@@ -4,9 +4,10 @@ import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
 import com.scmcloud.inventory.domain.entity.Inventory;
 import com.scmcloud.inventory.mapper.InvInventoryMapper;
 import com.scmcloud.order.api.OrderDubboService;
-import com.scmcloud.order.domain.entity.Order;
+import com.scmcloud.order.api.request.CreateOrderRequest;
+import com.scmcloud.order.domain.entity.OrdOrder;
 import com.scmcloud.order.mapper.OrdOrderMapper;
-import com.scmcloud.order.service.impl.OrderDubboServiceImpl;
+import com.scmcloud.order.service.dubbo.OrderDubboServiceImpl;
 import com.scmcloud.order.service.impl.OrderTccServiceImpl;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -52,8 +53,8 @@ public class PerformanceTest {
         log.info("========================================");
 
         orderMapper.delete(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, PERF_TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, PERF_TEST_USER_ID)
         );
         inventoryMapper.delete(
                 new LambdaQueryWrapper<Inventory>()
@@ -89,7 +90,7 @@ public class PerformanceTest {
             long reqStartTime = System.nanoTime();
 
             try {
-                OrderDubboService.CreateOrderRequest request = createRequest(
+                CreateOrderRequest request = createRequest(
                         PERF_TEST_USER_ID + i, PERF_TEST_SKU_ID, 1);
                 orderAtService.createOrder(request);
 
@@ -142,7 +143,7 @@ public class PerformanceTest {
                     long reqStartTime = System.nanoTime();
                     long userId = requestIdCounter.incrementAndGet();
 
-                    OrderDubboService.CreateOrderRequest request = createRequest(
+                    CreateOrderRequest request = createRequest(
                             userId, PERF_TEST_SKU_ID, 1);
                     orderAtService.createOrder(request);
 
@@ -194,7 +195,7 @@ public class PerformanceTest {
             long reqStartTime = System.nanoTime();
 
             try {
-                OrderDubboService.CreateOrderRequest request = createRequest(
+                CreateOrderRequest request = createRequest(
                         PERF_TEST_USER_ID + 20000 + i, PERF_TEST_SKU_ID, 1);
                 orderTccService.createOrderWithTcc(request);
 
@@ -248,7 +249,7 @@ public class PerformanceTest {
                     long reqStartTime = System.nanoTime();
                     long userId = requestIdCounter.incrementAndGet();
 
-                    OrderDubboService.CreateOrderRequest request = createRequest(
+                    CreateOrderRequest request = createRequest(
                             userId, PERF_TEST_SKU_ID, 1);
                     orderTccService.createOrderWithTcc(request);
 
@@ -318,8 +319,8 @@ public class PerformanceTest {
         log.info("Cleaning up performance test data...");
 
         orderMapper.delete(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, PERF_TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, PERF_TEST_USER_ID)
         );
 
         inventoryMapper.delete(
@@ -330,8 +331,8 @@ public class PerformanceTest {
         log.info("Perf test data cleanup completed");
     }
 
-    private OrderDubboService.CreateOrderRequest createRequest(Long userId, Long skuId, Integer quantity) {
-        OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+    private CreateOrderRequest createRequest(Long userId, Long skuId, Integer quantity) {
+        CreateOrderRequest request = new CreateOrderRequest();
         request.setUserId(userId);
         request.setSkuId(skuId);
         request.setSkuName("PerfTest-Product");

--- a/scm-order/service/src/test/java/com/scmcloud/order/SeataAtModeIntegrationTest.java
+++ b/scm-order/service/src/test/java/com/scmcloud/order/SeataAtModeIntegrationTest.java
@@ -5,9 +5,10 @@ import com.scmcloud.inventory.api.InventoryDubboService;
 import com.scmcloud.inventory.domain.entity.Inventory;
 import com.scmcloud.inventory.mapper.InvInventoryMapper;
 import com.scmcloud.order.api.OrderDubboService;
-import com.scmcloud.order.domain.entity.Order;
+import com.scmcloud.order.api.request.CreateOrderRequest;
+import com.scmcloud.order.domain.entity.OrdOrder;
 import com.scmcloud.order.mapper.OrdOrderMapper;
-import com.scmcloud.order.service.impl.OrderDubboServiceImpl;
+import com.scmcloud.order.service.dubbo.OrderDubboServiceImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.dubbo.config.annotation.DubboReference;
@@ -46,8 +47,8 @@ public class SeataAtModeIntegrationTest {
         log.info("========================================");
 
         orderMapper.delete(
-                new LambdaQueryWrapper<Order>()
-                        .eq(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .eq(OrdOrder::getUserId, TEST_USER_ID)
         );
         inventoryMapper.delete(
                 new LambdaQueryWrapper<Inventory>()
@@ -72,7 +73,7 @@ public class SeataAtModeIntegrationTest {
         log.info("Test Scenario 1: Order success, global transaction commit");
         log.info("========================================");
 
-        OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+        CreateOrderRequest request = new CreateOrderRequest();
         request.setUserId(TEST_USER_ID);
         request.setSkuId(TEST_SKU_ID);
         request.setSkuName("TestProduct");
@@ -89,9 +90,9 @@ public class SeataAtModeIntegrationTest {
 
         log.info("Order created successfully: OrderNo={}", orderVO.getOrderNo());
 
-        Order orderInDb = orderMapper.selectOne(
-                new LambdaQueryWrapper<Order>()
-                        .eq(Order::getOrderNo, orderVO.getOrderNo())
+        OrdOrder orderInDb = orderMapper.selectOne(
+                new LambdaQueryWrapper<OrdOrder>()
+                        .eq(OrdOrder::getOrderNo, orderVO.getOrderNo())
         );
         assertNotNull(orderInDb, "Order should exist in database");
         assertEquals(TEST_SKU_ID, orderInDb.getSkuId(), "SKU ID should match");
@@ -121,7 +122,7 @@ public class SeataAtModeIntegrationTest {
         log.info("Test Scenario 2: Insufficient stock, global transaction rollback");
         log.info("========================================");
 
-        OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+        CreateOrderRequest request = new CreateOrderRequest();
         request.setUserId(TEST_USER_ID);
         request.setSkuId(TEST_SKU_ID);
         request.setSkuName("TestProduct");
@@ -138,8 +139,8 @@ public class SeataAtModeIntegrationTest {
         assertTrue(exception.getMessage().contains("insufficient"), "Exception should contain 'insufficient'");
 
         Long orderCount = orderMapper.selectCount(
-                new LambdaQueryWrapper<Order>()
-                        .eq(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .eq(OrdOrder::getUserId, TEST_USER_ID)
         );
         assertEquals(0L, orderCount, "Database should have no order records (rolled back)");
 
@@ -176,7 +177,7 @@ public class SeataAtModeIntegrationTest {
             final int index = i;
             threads[i] = new Thread(() -> {
                 try {
-                    OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+                    CreateOrderRequest request = new CreateOrderRequest();
                     request.setUserId(TEST_USER_ID + index);
                     request.setSkuId(TEST_SKU_ID);
                     request.setSkuName("TestProduct");
@@ -226,8 +227,8 @@ public class SeataAtModeIntegrationTest {
         log.info("========================================");
 
         orderMapper.delete(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, TEST_USER_ID)
         );
 
         inventoryMapper.delete(

--- a/scm-order/service/src/test/java/com/scmcloud/order/SeataTccModeIntegrationTest.java
+++ b/scm-order/service/src/test/java/com/scmcloud/order/SeataTccModeIntegrationTest.java
@@ -6,7 +6,8 @@ import com.scmcloud.inventory.domain.entity.Inventory;
 import com.scmcloud.inventory.mapper.InvInventoryMapper;
 import com.scmcloud.inventory.mapper.InvTccReservationMapper;
 import com.scmcloud.order.api.OrderDubboService;
-import com.scmcloud.order.domain.entity.Order;
+import com.scmcloud.order.api.request.CreateOrderRequest;
+import com.scmcloud.order.domain.entity.OrdOrder;
 import com.scmcloud.order.mapper.OrdOrderMapper;
 import com.scmcloud.order.service.impl.OrderTccServiceImpl;
 import lombok.RequiredArgsConstructor;
@@ -47,8 +48,8 @@ public class SeataTccModeIntegrationTest {
         log.info("========================================");
 
         orderMapper.delete(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, TEST_USER_ID)
         );
         inventoryMapper.delete(
                 new LambdaQueryWrapper<Inventory>()
@@ -77,7 +78,7 @@ public class SeataTccModeIntegrationTest {
         log.info("Test Scenario 1: Try-Confirm flow");
         log.info("========================================");
 
-        OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+        CreateOrderRequest request = new CreateOrderRequest();
         request.setUserId(TEST_USER_ID);
         request.setSkuId(TEST_SKU_ID);
         request.setSkuName("TCC-TestProduct");
@@ -95,9 +96,9 @@ public class SeataTccModeIntegrationTest {
 
         log.info("Order created successfully: OrderNo={}", orderVO.getOrderNo());
 
-        Order orderInDb = orderMapper.selectOne(
-                new LambdaQueryWrapper<Order>()
-                        .eq(Order::getOrderNo, orderVO.getOrderNo())
+        OrdOrder orderInDb = orderMapper.selectOne(
+                new LambdaQueryWrapper<OrdOrder>()
+                        .eq(OrdOrder::getOrderNo, orderVO.getOrderNo())
         );
         assertNotNull(orderInDb, "Order should exist in database");
         assertEquals(TEST_SKU_ID, orderInDb.getSkuId(), "SKU ID should match");
@@ -148,7 +149,7 @@ public class SeataTccModeIntegrationTest {
         log.info("Test Scenario 2: Try-Cancel flow (insufficient stock)");
         log.info("========================================");
 
-        OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+        CreateOrderRequest request = new CreateOrderRequest();
         request.setUserId(TEST_USER_ID);
         request.setSkuId(TEST_SKU_ID);
         request.setSkuName("TCC-TestProduct");
@@ -165,8 +166,8 @@ public class SeataTccModeIntegrationTest {
         assertTrue(exception.getMessage().contains("stock"), "Exception should contain 'stock'");
 
         Long orderCount = orderMapper.selectCount(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, TEST_USER_ID)
         );
         assertEquals(0L, orderCount, "Database should have no order records (rolled back)");
 
@@ -206,7 +207,7 @@ public class SeataTccModeIntegrationTest {
         log.info("Test Scenario 3: TCC idempotency test");
         log.info("========================================");
 
-        OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+        CreateOrderRequest request = new CreateOrderRequest();
         request.setUserId(TEST_USER_ID);
         request.setSkuId(TEST_SKU_ID);
         request.setSkuName("TCC-TestProduct");
@@ -266,7 +267,7 @@ public class SeataTccModeIntegrationTest {
             final int index = i;
             threads[i] = new Thread(() -> {
                 try {
-                    OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+                    CreateOrderRequest request = new CreateOrderRequest();
                     request.setUserId(TEST_USER_ID + index);
                     request.setSkuId(TEST_SKU_ID);
                     request.setSkuName("TCC-TestProduct");
@@ -316,8 +317,8 @@ public class SeataTccModeIntegrationTest {
         log.info("TCC reservation consistency verified: {} CONFIRMED records", reservationCount);
 
         Long orderCount = orderMapper.selectCount(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, TEST_USER_ID)
         );
         assertEquals((long) successCount.get(), orderCount,
                 "Order count should equal success count");
@@ -337,7 +338,7 @@ public class SeataTccModeIntegrationTest {
         log.info("Test Scenario 5: TCC state transition verification");
         log.info("========================================");
 
-        OrderDubboService.CreateOrderRequest request = new OrderDubboService.CreateOrderRequest();
+        CreateOrderRequest request = new CreateOrderRequest();
         request.setUserId(TEST_USER_ID);
         request.setSkuId(TEST_SKU_ID);
         request.setSkuName("TCC-TestProduct");
@@ -390,8 +391,8 @@ public class SeataTccModeIntegrationTest {
         log.info("========================================");
 
         orderMapper.delete(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, TEST_USER_ID)
         );
 
         inventoryMapper.delete(

--- a/scm-order/service/src/test/java/com/scmcloud/order/XxlJobIntegrationTest.java
+++ b/scm-order/service/src/test/java/com/scmcloud/order/XxlJobIntegrationTest.java
@@ -1,7 +1,7 @@
 package com.scmcloud.order;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
-import com.scmcloud.order.domain.entity.Order;
+import com.scmcloud.order.domain.entity.OrdOrder;
 import com.scmcloud.order.job.OrderTimeoutCancelJobHandler;
 import com.scmcloud.order.mapper.OrdOrderMapper;
 import com.xxl.job.core.handler.annotation.XxlJob;
@@ -38,8 +38,8 @@ public class XxlJobIntegrationTest {
         log.info("========================================");
 
         orderMapper.delete(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, TEST_USER_ID)
         );
 
         log.info("Test data cleanup completed");
@@ -53,7 +53,7 @@ public class XxlJobIntegrationTest {
         log.info("Test Scenario 1: Order timeout cancel (normal timeout)");
         log.info("========================================");
 
-        Order timeoutOrder = createTestOrder(TEST_USER_ID, 1L, 10, "PENDING_PAYMENT");
+        OrdOrder timeoutOrder = createTestOrder(TEST_USER_ID, 1L, 10, "PENDING_PAYMENT");
         timeoutOrder.setCreateTime(LocalDateTime.now().minusMinutes(35));
         orderMapper.insert(timeoutOrder);
 
@@ -63,7 +63,7 @@ public class XxlJobIntegrationTest {
         log.info("Executing OrderTimeoutCancelJobHandler...");
         orderTimeoutCancelJobHandler.execute();
 
-        Order updatedOrder = orderMapper.selectById(timeoutOrder.getId());
+        OrdOrder updatedOrder = orderMapper.selectById(timeoutOrder.getId());
         assertNotNull(updatedOrder, "Order should exist");
         assertEquals("CANCELLED", updatedOrder.getStatus(), "Order status should be CANCELLED");
         assertNotNull(updatedOrder.getCancelTime(), "Cancel time should not be null");
@@ -84,7 +84,7 @@ public class XxlJobIntegrationTest {
         log.info("Test Scenario 2: Order timeout cancel (not timed out)");
         log.info("========================================");
 
-        Order validOrder = createTestOrder(TEST_USER_ID, 2L, 10, "PENDING_PAYMENT");
+        OrdOrder validOrder = createTestOrder(TEST_USER_ID, 2L, 10, "PENDING_PAYMENT");
         validOrder.setCreateTime(LocalDateTime.now().minusMinutes(10));
         orderMapper.insert(validOrder);
 
@@ -94,7 +94,7 @@ public class XxlJobIntegrationTest {
         log.info("Executing OrderTimeoutCancelJobHandler...");
         orderTimeoutCancelJobHandler.execute();
 
-        Order updatedOrder = orderMapper.selectById(validOrder.getId());
+        OrdOrder updatedOrder = orderMapper.selectById(validOrder.getId());
         assertNotNull(updatedOrder, "Order should exist");
         assertEquals("PENDING_PAYMENT", updatedOrder.getStatus(), "Order status should remain PENDING_PAYMENT");
         assertNull(updatedOrder.getCancelTime(), "Cancel time should be null");
@@ -117,7 +117,7 @@ public class XxlJobIntegrationTest {
 
         int batchSize = 5;
         for (int i = 0; i < batchSize; i++) {
-            Order timeoutOrder = createTestOrder(TEST_USER_ID + i, (long) (100 + i), 10, "PENDING_PAYMENT");
+            OrdOrder timeoutOrder = createTestOrder(TEST_USER_ID + i, (long) (100 + i), 10, "PENDING_PAYMENT");
             timeoutOrder.setCreateTime(LocalDateTime.now().minusMinutes(35 + i));
             orderMapper.insert(timeoutOrder);
             log.info("Created timed out order {}: OrderNo={}", i + 1, timeoutOrder.getOrderNo());
@@ -127,9 +127,9 @@ public class XxlJobIntegrationTest {
         orderTimeoutCancelJobHandler.execute();
 
         Long cancelledCount = orderMapper.selectCount(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, TEST_USER_ID)
-                        .eq(Order::getStatus, "CANCELLED")
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, TEST_USER_ID)
+                        .eq(OrdOrder::getStatus, "CANCELLED")
         );
 
         assertEquals((long) batchSize, cancelledCount, "Should cancel " + batchSize + " orders");
@@ -149,7 +149,7 @@ public class XxlJobIntegrationTest {
         log.info("Test Scenario 4: Order timeout cancel (custom timeout parameter)");
         log.info("========================================");
 
-        Order order = createTestOrder(TEST_USER_ID, 3L, 10, "PENDING_PAYMENT");
+        OrdOrder order = createTestOrder(TEST_USER_ID, 3L, 10, "PENDING_PAYMENT");
         order.setCreateTime(LocalDateTime.now().minusMinutes(20));
         orderMapper.insert(order);
 
@@ -158,7 +158,7 @@ public class XxlJobIntegrationTest {
         log.info("Executing OrderTimeoutCancelJobHandler (timeout=15 mins)...");
         orderTimeoutCancelJobHandler.execute();
 
-        Order updatedOrder = orderMapper.selectById(order.getId());
+        OrdOrder updatedOrder = orderMapper.selectById(order.getId());
         assertEquals("PENDING_PAYMENT", updatedOrder.getStatus(),
                 "20-min old order, default 30-min timeout, should not be cancelled");
 
@@ -178,7 +178,7 @@ public class XxlJobIntegrationTest {
         log.info("Test Scenario 5: Order timeout cancel (paid order)");
         log.info("========================================");
 
-        Order paidOrder = createTestOrder(TEST_USER_ID, 4L, 10, "PAID");
+        OrdOrder paidOrder = createTestOrder(TEST_USER_ID, 4L, 10, "PAID");
         paidOrder.setCreateTime(LocalDateTime.now().minusMinutes(35));
         paidOrder.setPayTime(LocalDateTime.now().minusMinutes(30));
         orderMapper.insert(paidOrder);
@@ -189,7 +189,7 @@ public class XxlJobIntegrationTest {
         log.info("Executing OrderTimeoutCancelJobHandler...");
         orderTimeoutCancelJobHandler.execute();
 
-        Order updatedOrder = orderMapper.selectById(paidOrder.getId());
+        OrdOrder updatedOrder = orderMapper.selectById(paidOrder.getId());
         assertEquals("PAID", updatedOrder.getStatus(), "Paid order should not be cancelled");
         assertNull(updatedOrder.getCancelTime(), "Cancel time should be null");
 
@@ -209,7 +209,7 @@ public class XxlJobIntegrationTest {
         log.info("Test Scenario 6: Order timeout cancel (already cancelled order)");
         log.info("========================================");
 
-        Order cancelledOrder = createTestOrder(TEST_USER_ID, 5L, 10, "CANCELLED");
+        OrdOrder cancelledOrder = createTestOrder(TEST_USER_ID, 5L, 10, "CANCELLED");
         cancelledOrder.setCreateTime(LocalDateTime.now().minusMinutes(35));
         cancelledOrder.setCancelTime(LocalDateTime.now().minusMinutes(5));
         orderMapper.insert(cancelledOrder);
@@ -222,7 +222,7 @@ public class XxlJobIntegrationTest {
         log.info("Executing OrderTimeoutCancelJobHandler...");
         orderTimeoutCancelJobHandler.execute();
 
-        Order updatedOrder = orderMapper.selectById(cancelledOrder.getId());
+        OrdOrder updatedOrder = orderMapper.selectById(cancelledOrder.getId());
         assertEquals("CANCELLED", updatedOrder.getStatus(), "Order status should remain CANCELLED");
         assertEquals(originalCancelTime, updatedOrder.getCancelTime(),
                 "Cancel time should not change (idempotency)");
@@ -272,15 +272,15 @@ public class XxlJobIntegrationTest {
         log.info("========================================");
 
         orderMapper.delete(
-                new LambdaQueryWrapper<Order>()
-                        .ge(Order::getUserId, TEST_USER_ID)
+                new LambdaQueryWrapper<OrdOrder>()
+                        .ge(OrdOrder::getUserId, TEST_USER_ID)
         );
 
         log.info("XXL-Job test data cleanup completed");
     }
 
-    private Order createTestOrder(Long userId, Long skuId, Integer quantity, String status) {
-        Order order = new Order();
+    private OrdOrder createTestOrder(Long userId, Long skuId, Integer quantity, String status) {
+        OrdOrder order = new OrdOrder();
         order.setOrderNo("TEST" + System.currentTimeMillis() + userId);
         order.setUserId(userId);
         order.setSkuId(skuId);


### PR DESCRIPTION
Closes #89

## Root cause
Test files referenced:
- \Order\ (entity) instead of \OrdOrder\
- \com.scmcloud.order.service.impl.OrderDubboServiceImpl\ instead of \com.scmcloud.order.service.dubbo.OrderDubboServiceImpl\
- \OrderDubboService.CreateOrderRequest\ instead of importing \com.scmcloud.order.api.request.CreateOrderRequest\

## Fix
Replaced all incorrect type references in PerformanceTest, SeataAtModeIntegrationTest, SeataTccModeIntegrationTest, and XxlJobIntegrationTest.