### PR TITLE
fix: TenantAwareMDCTaskDecoratorTest queue capacity too small

### DIFF
--- a/scm-common/core/src/test/java/com/scmcloud/common/tenant/TenantAwareMDCTaskDecoratorTest.java
+++ b/scm-common/core/src/test/java/com/scmcloud/common/tenant/TenantAwareMDCTaskDecoratorTest.java
@@ -158,7 +158,7 @@ class TenantAwareMDCTaskDecoratorTest {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(1);
         executor.setMaxPoolSize(1);
-        executor.setQueueCapacity(1);
+        executor.setQueueCapacity(5);
         executor.setThreadNamePrefix("test-async-");
         return executor;
     }


### PR DESCRIPTION
Closes #93

queueCapacity=1 causes TaskRejected when 3 async tasks are submitted simultaneously. Increased to 5.