### PR TITLE
fix: scm-file and scm-message code review issues

### DIFF
--- a/com.scm.parent/pom.xml
+++ b/com.scm.parent/pom.xml
@@ -40,6 +40,9 @@
 
     <!-- File Service -->
     <module>../scm-file</module>
+
+    <!-- Message Service -->
+    <module>../scm-message</module>
   </modules>
 
   <parent>

--- a/com.scm.parent/pom.xml
+++ b/com.scm.parent/pom.xml
@@ -37,6 +37,9 @@
     <!-- Supplier & Finance Layer -->
     <module>../scm-supplier</module>
     <module>../scm-finance</module>
+
+    <!-- File Service -->
+    <module>../scm-file</module>
   </modules>
 
   <parent>

--- a/docs/superpowers/plans/2026-06-18-scm-file-implementation.md
+++ b/docs/superpowers/plans/2026-06-18-scm-file-implementation.md
@@ -1,0 +1,1425 @@
+# scm-file Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build unified file storage service with multi-backend support, instant upload, resume upload, and version management.
+
+**Architecture:** New Spring Boot module with SPI-based storage engine abstraction (MinIO/OSS/S3), metadata in PostgreSQL, cache in Redis. Uses Dubbo RPC for service exposure.
+
+**Tech Stack:** Spring Boot 4.x, MinIO SDK, MyBatis-Plus, Redis, Dubbo 3.x
+
+---
+
+## File Structure
+
+```
+scm-file/
+├── pom.xml
+├── api/
+│   ├── pom.xml
+│   └── src/main/java/com/scmcloud/file/api/
+│       ├── FileQueryApi.java
+│       ├── FileManageApi.java
+│       ├── dto/
+│       │   └── FileMetadataDTO.java
+│       └── enums/
+│           ├── StorageType.java
+│           └── UploadTaskStatus.java
+├── service/
+│   ├── pom.xml
+│   └── src/
+│       ├── main/
+│       │   ├── java/com/scmcloud/file/
+│       │   │   ├── ScmFileApplication.java
+│       │   │   ├── config/
+│       │   │   │   ├── FileConfig.java
+│       │   │   │   └── StorageConfig.java
+│       │   │   ├── controller/
+│       │   │   │   └── FileController.java
+│       │   │   ├── convert/
+│       │   │   │   └── FileMetadataConvert.java
+│       │   │   ├── service/
+│       │   │   │   ├── storage/
+│       │   │   │   │   ├── StorageEngine.java
+│       │   │   │   │   ├── StorageFactory.java
+│       │   │   │   │   ├── MinioStorageEngine.java
+│       │   │   │   │   ├── OssStorageEngine.java
+│       │   │   │   │   └── S3StorageEngine.java
+│       │   │   │   ├── upload/
+│       │   │   │   │   ├── UploadService.java
+│       │   │   │   │   ├── InstantUploadService.java
+│       │   │   │   │   └── ResumeUploadService.java
+│       │   │   │   ├── metadata/
+│       │   │   │   │   ├── FileMetadataService.java
+│       │   │   │   │   └── FileVersionService.java
+│       │   │   │   └── preview/
+│       │   │   │       ├── ImagePreviewService.java
+│       │   │   │       └── DocumentPreviewService.java
+│       │   │   ├── entity/
+│       │   │   │   ├── FileMetadata.java
+│       │   │   │   ├── FileVersion.java
+│       │   │   │   └── UploadTask.java
+│       │   │   └── mapper/
+│       │   │       ├── FileMetadataMapper.java
+│       │   │       ├── FileVersionMapper.java
+│       │   │       └── UploadTaskMapper.java
+│       │   └── resources/
+│       │       ├── application.yml
+│       │       └── db/migration/
+│       │           └── V1_0_0__create_file_tables.sql
+│       └── test/
+│           └── java/com/scmcloud/file/
+│               ├── service/
+│               │   ├── storage/
+│               │   │   └── StorageEngineTest.java
+│               │   ├── upload/
+│               │   │   ├── UploadServiceTest.java
+│               │   │   └── InstantUploadServiceTest.java
+│               │   └── metadata/
+│               │       └── FileMetadataServiceTest.java
+│               └── integration/
+│                   └── FileUploadIntegrationTest.java
+```
+
+---
+
+## Task 1: Create Module Structure
+
+**Files:**
+- Create: `scm-file/pom.xml`
+- Create: `scm-file/api/pom.xml`
+- Create: `scm-file/service/pom.xml`
+- Modify: `com.scm.parent/pom.xml`
+
+- [ ] **Step 1: Create parent POM for scm-file**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.scmcloud</groupId>
+    <artifactId>scm-file</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>SCM File Service</name>
+    <description>Unified file storage service</description>
+
+    <modules>
+        <module>api</module>
+        <module>service</module>
+    </modules>
+</project>
+```
+
+- [ ] **Step 2: Create API module POM**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-file</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scm-file-api</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+- [ ] **Step 3: Create service module POM**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-file</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scm-file-service</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-file-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-data</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>8.5.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.aliyun.oss</groupId>
+            <artifactId>aliyun-sdk-oss</artifactId>
+            <version>3.17.4</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+- [ ] **Step 4: Add scm-file to parent POM**
+
+Add to `com.scm.parent/pom.xml` in `<modules>`:
+```xml
+<module>../scm-file</module>
+```
+
+- [ ] **Step 5: Verify build**
+
+```bash
+mvn clean install -f scm-file/pom.xml -DskipTests
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scm-file/ com.scm.parent/pom.xml
+git commit -m "feat(file): create scm-file module structure"
+```
+
+---
+
+## Task 2: Create Database Schema
+
+**Files:**
+- Create: `scm-file/service/src/main/resources/db/migration/V1_0_0__create_file_tables.sql`
+
+- [ ] **Step 1: Write migration SQL**
+
+```sql
+-- File metadata table
+CREATE TABLE sys_file_metadata (
+    id              VARCHAR(36) PRIMARY KEY,
+    original_name   VARCHAR(255) NOT NULL,
+    storage_key     VARCHAR(500) NOT NULL,
+    content_type    VARCHAR(100),
+    file_size       BIGINT,
+    storage_engine  VARCHAR(50) NOT NULL,
+    md5             VARCHAR(32),
+    version         INTEGER DEFAULT 1,
+    biz_type        VARCHAR(50),
+    biz_id          VARCHAR(100),
+    status          VARCHAR(20) DEFAULT 'NORMAL',
+    ref_count       INTEGER DEFAULT 1,
+    tenant_id       BIGINT NOT NULL,
+    create_by       BIGINT,
+    update_by       BIGINT,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    update_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted         INTEGER DEFAULT 0
+);
+
+CREATE INDEX idx_file_metadata_md5 ON sys_file_metadata(md5);
+CREATE INDEX idx_file_metadata_tenant ON sys_file_metadata(tenant_id);
+CREATE INDEX idx_file_metadata_biz ON sys_file_metadata(biz_type, biz_id);
+
+-- File version table
+CREATE TABLE sys_file_version (
+    id              VARCHAR(36) PRIMARY KEY,
+    file_id         VARCHAR(36) NOT NULL,
+    version         INTEGER NOT NULL,
+    storage_key     VARCHAR(500) NOT NULL,
+    file_size       BIGINT,
+    md5             VARCHAR(32),
+    create_by       BIGINT,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    tenant_id       BIGINT NOT NULL
+);
+
+CREATE INDEX idx_file_version_file_id ON sys_file_version(file_id);
+
+-- Upload task table
+CREATE TABLE sys_upload_task (
+    id              VARCHAR(36) PRIMARY KEY,
+    file_name       VARCHAR(255) NOT NULL,
+    file_size       BIGINT NOT NULL,
+    md5             VARCHAR(32),
+    storage_key     VARCHAR(500),
+    total_parts     INTEGER,
+    completed_parts INTEGER DEFAULT 0,
+    status          SMALLINT NOT NULL DEFAULT 0,
+    upload_id       VARCHAR(100),
+    tenant_id       BIGINT NOT NULL,
+    create_by       BIGINT,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    update_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted         INTEGER DEFAULT 0,
+    lock_version    INTEGER DEFAULT 0
+);
+
+CREATE INDEX idx_upload_task_status ON sys_upload_task(status);
+CREATE INDEX idx_upload_task_md5 ON sys_upload_task(md5);
+```
+
+- [ ] **Step 2: Run migration**
+
+```bash
+mvn flyway:migrate -f scm-file/service/pom.xml
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scm-file/service/src/main/resources/db/migration/
+git commit -m "feat(file): add database schema for file storage"
+```
+
+---
+
+## Task 3: Create Entity and Mapper Classes
+
+**Files:**
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/entity/FileMetadata.java`
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/entity/FileVersion.java`
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/entity/UploadTask.java`
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/mapper/FileMetadataMapper.java`
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/mapper/FileVersionMapper.java`
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/mapper/UploadTaskMapper.java`
+
+- [ ] **Step 1: Create FileMetadata entity**
+
+```java
+package com.scmcloud.file.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import java.util.Date;
+
+@Data
+@TableName("sys_file_metadata")
+public class FileMetadata {
+    @TableId(type = IdType.ASSIGN_UUID)
+    private String id;
+    private String originalName;
+    private String storageKey;
+    private String contentType;
+    private Long fileSize;
+    private String storageEngine;
+    private String md5;
+    private Integer version;
+    private String bizType;
+    private String bizId;
+    private String status;
+    private Integer refCount;
+    private Long tenantId;
+    private Long createBy;
+    private Long updateBy;
+    private Date createTime;
+    private Date updateTime;
+    @TableLogic
+    private Integer deleted;
+}
+```
+
+- [ ] **Step 2: Create FileVersion entity**
+
+```java
+package com.scmcloud.file.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import java.util.Date;
+
+@Data
+@TableName("sys_file_version")
+public class FileVersion {
+    @TableId(type = IdType.ASSIGN_UUID)
+    private String id;
+    private String fileId;
+    private Integer version;
+    private String storageKey;
+    private Long fileSize;
+    private String md5;
+    private Long createBy;
+    private Date createTime;
+    private Long tenantId;
+}
+```
+
+- [ ] **Step 3: Create UploadTask entity**
+
+```java
+package com.scmcloud.file.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import com.scmcloud.file.api.enums.UploadTaskStatus;
+import lombok.Data;
+import java.util.Date;
+
+@Data
+@TableName("sys_upload_task")
+public class UploadTask {
+    @TableId(type = IdType.ASSIGN_UUID)
+    private String id;
+    private String fileName;
+    private Long fileSize;
+    private String md5;
+    private String storageKey;
+    private Integer totalParts;
+    private Integer completedParts;
+    private UploadTaskStatus status;
+    private String uploadId;
+    private Long tenantId;
+    private Long createBy;
+    private Date createTime;
+    private Date updateTime;
+    @TableLogic
+    private Integer deleted;
+    @Version
+    private Integer lockVersion;
+}
+```
+
+- [ ] **Step 4: Create mapper interfaces**
+
+```java
+package com.scmcloud.file.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.scmcloud.file.entity.FileMetadata;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface FileMetadataMapper extends BaseMapper<FileMetadata> {
+}
+```
+
+```java
+package com.scmcloud.file.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.scmcloud.file.entity.FileVersion;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface FileVersionMapper extends BaseMapper<FileVersion> {
+}
+```
+
+```java
+package com.scmcloud.file.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.scmcloud.file.entity.UploadTask;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UploadTaskMapper extends BaseMapper<UploadTask> {
+}
+```
+
+- [ ] **Step 5: Create FileMetadataConvert (MapStruct)**
+
+```java
+package com.scmcloud.file.convert;
+
+import com.scmcloud.file.api.dto.FileMetadataDTO;
+import com.scmcloud.file.entity.FileMetadata;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface FileMetadataConvert {
+    
+    FileMetadataDTO toDTO(FileMetadata entity);
+    
+    FileMetadata toEntity(FileMetadataDTO dto);
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scm-file/service/src/main/java/com/scmcloud/file/entity/ scm-file/service/src/main/java/com/scmcloud/file/mapper/ scm-file/service/src/main/java/com/scmcloud/file/convert/
+git commit -m "feat(file): add entity, mapper and converter classes"
+```
+
+---
+
+## Task 4: Create Storage SPI Interface
+
+**Files:**
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageEngine.java`
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageFactory.java`
+- Create: `scm-file/api/src/main/java/com/scmcloud/file/api/enums/StorageType.java`
+
+- [ ] **Step 1: Create StorageType enum**
+
+```java
+package com.scmcloud.file.api.enums;
+
+public enum StorageType {
+    MINIO,
+    OSS,
+    S3
+}
+```
+
+Create UploadTaskStatus enum:
+
+```java
+package com.scmcloud.file.api.enums;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+import lombok.Getter;
+
+@Getter
+public enum UploadTaskStatus {
+    INIT(0, "Initial"),
+    UPLOADING(1, "Uploading"),
+    SUCCESS(2, "Success"),
+    FAILED(3, "Failed");
+    
+    @EnumValue
+    private final int code;
+    private final String desc;
+    
+    UploadTaskStatus(int code, String desc) {
+        this.code = code;
+        this.desc = desc;
+    }
+}
+```
+
+- [ ] **Step 2: Create StorageEngine interface**
+
+```java
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.entity.FileMetadata;
+import java.io.InputStream;
+import java.time.Duration;
+
+public interface StorageEngine {
+    
+    FileMetadata upload(byte[] fileBytes, String fileName, String contentType, Long tenantId);
+    
+    InputStream download(String fileKey);
+    
+    String generatePresignedUrl(String fileKey, Duration expiry);
+    
+    void delete(String fileKey);
+    
+    boolean exists(String fileKey);
+    
+    StorageType support();
+}
+```
+
+- [ ] **Step 3: Create StorageFactory**
+
+```java
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class StorageFactory {
+    
+    private final List<StorageEngine> engineList;
+    private final Map<StorageType, StorageEngine> engineMap = new EnumMap<>(StorageType.class);
+    
+    public StorageFactory(List<StorageEngine> engineList) {
+        this.engineList = engineList;
+    }
+    
+    @PostConstruct
+    public void init() {
+        for (StorageEngine engine : engineList) {
+            StorageType type = engine.support();
+            engineMap.put(type, engine);
+            log.info("Registered storage engine: {} -> {}", type, engine.getClass().getSimpleName());
+        }
+    }
+    
+    public StorageEngine getEngine(StorageType type) {
+        StorageEngine engine = engineMap.get(type);
+        if (engine == null) {
+            throw new IllegalArgumentException("No storage engine found for type: " + type);
+        }
+        return engine;
+    }
+    
+    public StorageEngine getDefaultEngine() {
+        return getEngine(StorageType.MINIO);
+    }
+}
+```
+
+- [ ] **Step 4: Write test for StorageFactory**
+
+```java
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StorageFactoryTest {
+    
+    @Test
+    void shouldGetEngineByType() {
+        // Given
+        MinioStorageEngine minioEngine = mock(MinioStorageEngine.class);
+        when(minioEngine.support()).thenReturn(StorageType.MINIO);
+        
+        StorageFactory factory = new StorageFactory(List.of(minioEngine));
+        factory.init();
+        
+        // When
+        StorageEngine result = factory.getEngine(StorageType.MINIO);
+        
+        // Then
+        assertEquals(minioEngine, result);
+    }
+    
+    @Test
+    void shouldThrowExceptionForUnsupportedType() {
+        // Given
+        StorageFactory factory = new StorageFactory(List.of());
+        factory.init();
+        
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> factory.getEngine(StorageType.MINIO));
+    }
+}
+```
+
+- [ ] **Step 5: Run test**
+
+```bash
+mvn test -pl scm-file/service -Dtest=StorageFactoryTest -f com.scm.parent/pom.xml
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scm-file/service/src/main/java/com/scmcloud/file/service/storage/
+git commit -m "feat(file): add storage SPI interface and factory"
+```
+
+---
+
+## Task 5: Implement MinIO Storage Engine
+
+**Files:**
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/service/storage/MinioStorageEngine.java`
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/config/StorageConfig.java`
+
+- [ ] **Step 1: Create StorageConfig**
+
+```java
+package com.scmcloud.file.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "storage.minio")
+public class StorageConfig {
+    private String endpoint;
+    private String accessKey;
+    private String secretKey;
+    private String bucketName;
+    private boolean createBucket = true;
+}
+```
+
+- [ ] **Step 2: Write test for MinioStorageEngine**
+
+```java
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.config.StorageConfig;
+import com.scmcloud.file.entity.FileMetadata;
+import io.minio.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MinioStorageEngineTest {
+    
+    @Mock
+    private MinioClient minioClient;
+    
+    @Mock
+    private StorageConfig config;
+    
+    @InjectMocks
+    private MinioStorageEngine engine;
+    
+    @BeforeEach
+    void setUp() {
+        when(config.getBucketName()).thenReturn("test-bucket");
+    }
+    
+    @Test
+    void shouldUploadFile() throws Exception {
+        // Given
+        byte[] fileBytes = "test content".getBytes();
+        when(minioClient.putObject(any(PutObjectArgs.class))).thenReturn(null);
+        
+        // When
+        FileMetadata result = engine.upload(fileBytes, "test.txt", "text/plain", 1L);
+        
+        // Then
+        assertNotNull(result);
+        assertEquals("test.txt", result.getOriginalName());
+        assertEquals("text/plain", result.getContentType());
+        assertEquals(12L, result.getFileSize());
+        verify(minioClient).putObject(any(PutObjectArgs.class));
+    }
+    
+    @Test
+    void shouldCheckFileExists() throws Exception {
+        // Given
+        when(minioClient.statObject(any(StatObjectArgs.class))).thenReturn(null);
+        
+        // When
+        boolean exists = engine.exists("test-key");
+        
+        // Then
+        assertTrue(exists);
+    }
+}
+```
+
+- [ ] **Step 3: Implement MinioStorageEngine**
+
+```java
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import com.scmcloud.file.config.StorageConfig;
+import com.scmcloud.file.entity.FileMetadata;
+import io.minio.*;
+import io.minio.http.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MinioStorageEngine implements StorageEngine {
+    
+    private final MinioClient minioClient;
+    private final StorageConfig config;
+    
+    @Override
+    public FileMetadata upload(byte[] fileBytes, String fileName, String contentType, Long tenantId) {
+        try {
+            String storageKey = generateStorageKey(tenantId, fileName);
+            
+            minioClient.putObject(PutObjectArgs.builder()
+                    .bucket(config.getBucketName())
+                    .object(storageKey)
+                    .stream(new ByteArrayInputStream(fileBytes), fileBytes.length, 10485760)
+                    .contentType(contentType)
+                    .build());
+            
+            FileMetadata metadata = new FileMetadata();
+            metadata.setOriginalName(fileName);
+            metadata.setStorageKey(storageKey);
+            metadata.setContentType(contentType);
+            metadata.setFileSize((long) fileBytes.length);
+            metadata.setStorageEngine("MINIO");
+            metadata.setTenantId(tenantId);
+            
+            return metadata;
+        } catch (Exception e) {
+            log.error("Failed to upload file to MinIO", e);
+            throw new RuntimeException("File upload failed", e);
+        }
+    }
+    
+    @Override
+    public InputStream download(String fileKey) {
+        try {
+            return minioClient.getObject(GetObjectArgs.builder()
+                    .bucket(config.getBucketName())
+                    .object(fileKey)
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to download file from MinIO", e);
+            throw new RuntimeException("File download failed", e);
+        }
+    }
+    
+    @Override
+    public String generatePresignedUrl(String fileKey, Duration expiry) {
+        try {
+            return minioClient.getPresignedObjectUrl(GetPresignedObjectUrlArgs.builder()
+                    .method(Method.GET)
+                    .bucket(config.getBucketName())
+                    .object(fileKey)
+                    .expiry((int) expiry.toSeconds())
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to generate presigned URL", e);
+            throw new RuntimeException("URL generation failed", e);
+        }
+    }
+    
+    @Override
+    public void delete(String fileKey) {
+        try {
+            minioClient.removeObject(RemoveObjectArgs.builder()
+                    .bucket(config.getBucketName())
+                    .object(fileKey)
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to delete file from MinIO", e);
+            throw new RuntimeException("File deletion failed", e);
+        }
+    }
+    
+    @Override
+    public boolean exists(String fileKey) {
+        try {
+            minioClient.statObject(StatObjectArgs.builder()
+                    .bucket(config.getBucketName())
+                    .object(fileKey)
+                    .build());
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    @Override
+    public StorageType support() {
+        return StorageType.MINIO;
+    }
+    
+    private String generateStorageKey(Long tenantId, String fileName) {
+        String extension = "";
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot > 0) {
+            extension = fileName.substring(lastDot);
+        }
+        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+        return tenantId + "/" + datePath + "/" + UUID.randomUUID() + extension;
+    }
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+mvn test -pl scm-file/service -Dtest=MinioStorageEngineTest -f com.scm.parent/pom.xml
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scm-file/service/src/main/java/com/scmcloud/file/service/storage/MinioStorageEngine.java
+git add scm-file/service/src/main/java/com/scmcloud/file/config/StorageConfig.java
+git commit -m "feat(file): implement MinIO storage engine"
+```
+
+---
+
+## Task 6: Create FileMetadata Service
+
+**Files:**
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/service/metadata/FileMetadataService.java`
+
+- [ ] **Step 1: Write test for FileMetadataService**
+
+```java
+package com.scmcloud.file.service.metadata;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.mapper.FileMetadataMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FileMetadataServiceTest {
+    
+    @Mock
+    private FileMetadataMapper mapper;
+    
+    @InjectMocks
+    private FileMetadataService service;
+    
+    @Test
+    void shouldSaveFileMetadata() {
+        // Given
+        FileMetadata metadata = new FileMetadata();
+        metadata.setId("test-id");
+        metadata.setOriginalName("test.txt");
+        when(mapper.insert(any())).thenReturn(1);
+        
+        // When
+        FileMetadata result = service.saveMetadata(metadata);
+        
+        // Then
+        assertNotNull(result);
+        verify(mapper).insert(metadata);
+    }
+    
+    @Test
+    void shouldFindByMd5() {
+        // Given
+        String md5 = "abc123";
+        FileMetadata metadata = new FileMetadata();
+        metadata.setMd5(md5);
+        when(mapper.selectOne(any(LambdaQueryWrapper.class))).thenReturn(metadata);
+        
+        // When
+        Optional<FileMetadata> result = service.findByMd5(md5, 1L);
+        
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(md5, result.get().getMd5());
+    }
+}
+```
+
+- [ ] **Step 2: Implement FileMetadataService**
+
+```java
+package com.scmcloud.file.service.metadata;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.mapper.FileMetadataMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class FileMetadataService extends ServiceImpl<FileMetadataMapper, FileMetadata> {
+    
+    public FileMetadata saveMetadata(FileMetadata metadata) {
+        save(metadata);
+        return metadata;
+    }
+    
+    public Optional<FileMetadata> findByMd5(String md5, Long tenantId) {
+        LambdaQueryWrapper<FileMetadata> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(FileMetadata::getMd5, md5)
+               .eq(FileMetadata::getTenantId, tenantId)
+               .eq(FileMetadata::getDeleted, 0);
+        return Optional.ofNullable(getOne(wrapper));
+    }
+    
+    public Optional<FileMetadata> findById(String id, Long tenantId) {
+        LambdaQueryWrapper<FileMetadata> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(FileMetadata::getId, id)
+               .eq(FileMetadata::getTenantId, tenantId)
+               .eq(FileMetadata::getDeleted, 0);
+        return Optional.ofNullable(getOne(wrapper));
+    }
+}
+```
+
+- [ ] **Step 3: Run test**
+
+```bash
+mvn test -pl scm-file/service -Dtest=FileMetadataServiceTest -f com.scm.parent/pom.xml
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scm-file/service/src/main/java/com/scmcloud/file/service/metadata/FileMetadataService.java
+git commit -m "feat(file): add FileMetadata service"
+```
+
+---
+
+## Task 7: Create API Interfaces
+
+**Files:**
+- Create: `scm-file/api/src/main/java/com/scmcloud/file/api/FileQueryApi.java`
+- Create: `scm-file/api/src/main/java/com/scmcloud/file/api/FileManageApi.java`
+- Create: `scm-file/api/src/main/java/com/scmcloud/file/api/dto/FileMetadataDTO.java`
+
+- [ ] **Step 1: Create FileMetadataDTO**
+
+```java
+package com.scmcloud.file.api.dto;
+
+import lombok.Data;
+import java.io.Serializable;
+import java.util.Date;
+
+@Data
+public class FileMetadataDTO implements Serializable {
+    private String id;
+    private String originalName;
+    private String storageKey;
+    private String contentType;
+    private Long fileSize;
+    private String storageEngine;
+    private String md5;
+    private Integer version;
+    private String bizType;
+    private String bizId;
+    private String status;
+    private Long tenantId;
+    private Date createTime;
+}
+```
+
+- [ ] **Step 2: Create FileQueryApi interface (Dubbo RPC)**
+
+```java
+package com.scmcloud.file.api;
+
+import com.scmcloud.file.api.dto.FileMetadataDTO;
+import java.util.List;
+
+public interface FileQueryApi {
+    
+    FileMetadataDTO getById(String id, Long tenantId);
+    
+    FileMetadataDTO getByMd5(String md5, Long tenantId);
+    
+    List<FileMetadataDTO> getByBizId(String bizType, String bizId, Long tenantId);
+    
+    String generatePresignedUrl(String fileKey, Long tenantId);
+}
+```
+
+- [ ] **Step 3: Create FileManageApi interface (Dubbo RPC)**
+
+```java
+package com.scmcloud.file.api;
+
+import com.scmcloud.file.api.dto.FileMetadataDTO;
+
+public interface FileManageApi {
+    
+    void delete(String id, Long tenantId);
+    
+    void updateBizAssociation(String id, String bizType, String bizId, Long tenantId);
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scm-file/api/src/main/java/com/scmcloud/file/api/
+git commit -m "feat(file): add FileQuery and FileManage API interfaces"
+```
+
+---
+
+## Task 8: Implement Upload Service
+
+**Files:**
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/service/upload/UploadService.java`
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/service/upload/InstantUploadService.java`
+
+- [ ] **Step 1: Write test for InstantUploadService**
+
+```java
+package com.scmcloud.file.service.upload;
+
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.service.metadata.FileMetadataService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InstantUploadServiceTest {
+    
+    @Mock
+    private FileMetadataService metadataService;
+    
+    @InjectMocks
+    private InstantUploadService service;
+    
+    @Test
+    void shouldReturnExistingFileWhenMd5Matches() {
+        // Given
+        String md5 = "abc123";
+        Long tenantId = 1L;
+        FileMetadata existing = new FileMetadata();
+        existing.setId("existing-id");
+        existing.setMd5(md5);
+        when(metadataService.findByMd5(md5, tenantId)).thenReturn(Optional.of(existing));
+        
+        // When
+        Optional<FileMetadata> result = service.checkExist(md5, tenantId);
+        
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals("existing-id", result.get().getId());
+    }
+    
+    @Test
+    void shouldReturnEmptyWhenMd5NotExists() {
+        // Given
+        String md5 = "not-exists";
+        Long tenantId = 1L;
+        when(metadataService.findByMd5(md5, tenantId)).thenReturn(Optional.empty());
+        
+        // When
+        Optional<FileMetadata> result = service.checkExist(md5, tenantId);
+        
+        // Then
+        assertFalse(result.isPresent());
+    }
+}
+```
+
+- [ ] **Step 2: Implement InstantUploadService**
+
+```java
+package com.scmcloud.file.service.upload;
+
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.service.metadata.FileMetadataService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InstantUploadService {
+    
+    private final FileMetadataService metadataService;
+    
+    public Optional<FileMetadata> checkExist(String md5, Long tenantId) {
+        return metadataService.findByMd5(md5, tenantId);
+    }
+}
+```
+
+- [ ] **Step 3: Implement UploadService**
+
+```java
+package com.scmcloud.file.service.upload;
+
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.entity.UploadTask;
+import com.scmcloud.file.mapper.UploadTaskMapper;
+import com.scmcloud.file.service.metadata.FileMetadataService;
+import com.scmcloud.file.service.storage.StorageEngine;
+import com.scmcloud.file.service.storage.StorageFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UploadService {
+    
+    private final StorageFactory storageFactory;
+    private final FileMetadataService metadataService;
+    private final InstantUploadService instantUploadService;
+    private final UploadTaskMapper uploadTaskMapper;
+    
+    @Transactional
+    public FileMetadata upload(byte[] fileBytes, String fileName, String contentType,
+                               String bizType, String bizId, Long tenantId) {
+        String md5 = DigestUtils.md5Hex(fileBytes);
+        
+        return instantUploadService.checkExist(md5, tenantId)
+                .orElseGet(() -> doUpload(fileBytes, fileName, contentType, md5, bizType, bizId, tenantId));
+    }
+    
+    private FileMetadata doUpload(byte[] fileBytes, String fileName, String contentType,
+                                   String md5, String bizType, String bizId, Long tenantId) {
+        StorageEngine engine = storageFactory.getDefaultEngine();
+        FileMetadata metadata = engine.upload(fileBytes, fileName, contentType, tenantId);
+        metadata.setMd5(md5);
+        metadata.setFileSize((long) fileBytes.length);
+        metadata.setVersion(1);
+        metadata.setBizType(bizType);
+        metadata.setBizId(bizId);
+        metadata.setCreateBy(tenantId); // TODO: get from TenantContextHolder
+        metadataService.saveMetadata(metadata);
+        return metadata;
+    }
+    
+    public String initMultipartUpload(String fileName, Long fileSize, Long tenantId) {
+        UploadTask task = new UploadTask();
+        task.setId(UUID.randomUUID().toString());
+        task.setFileName(fileName);
+        task.setFileSize(fileSize);
+        task.setStatus(UploadTaskStatus.INIT);
+        task.setTenantId(tenantId);
+        uploadTaskMapper.insert(task);
+        return task.getId();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+mvn test -pl scm-file/service -Dtest="InstantUploadServiceTest,UploadServiceTest" -f com.scm.parent/pom.xml
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scm-file/service/src/main/java/com/scmcloud/file/service/upload/
+git commit -m "feat(file): implement upload service with instant upload"
+```
+
+---
+
+## Task 9: Create REST Controller
+
+**Files:**
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/controller/FileController.java`
+
+- [ ] **Step 1: Implement FileController**
+
+```java
+package com.scmcloud.file.controller;
+
+import com.scmcloud.common.response.ApiResponse;
+import com.scmcloud.file.api.dto.FileMetadataDTO;
+import com.scmcloud.file.convert.FileMetadataConvert;
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.service.upload.InstantUploadService;
+import com.scmcloud.file.service.upload.UploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+public class FileController {
+    
+    private final UploadService uploadService;
+    private final InstantUploadService instantUploadService;
+    private final FileMetadataConvert fileMetadataConvert;
+    
+    @PostMapping("/upload")
+    public ApiResponse<FileMetadataDTO> upload(@RequestParam("file") MultipartFile file,
+                                                @RequestParam(value = "bizType", required = false) String bizType,
+                                                @RequestParam(value = "bizId", required = false) String bizId) {
+        try {
+            FileMetadata metadata = uploadService.upload(
+                    file.getBytes(),
+                    file.getOriginalFilename(),
+                    file.getContentType(),
+                    bizType,
+                    bizId,
+                    1L // TODO: get from TenantContextHolder
+            );
+            return ApiResponse.success(fileMetadataConvert.toDTO(metadata));
+        } catch (Exception e) {
+            return ApiResponse.error("Upload failed: " + e.getMessage());
+        }
+    }
+    
+    @GetMapping("/check/{md5}")
+    public ApiResponse<FileMetadataDTO> checkExist(@PathVariable String md5) {
+        return instantUploadService.checkExist(md5, 1L) // TODO: get from TenantContextHolder
+                .map(fileMetadataConvert::toDTO)
+                .map(ApiResponse::success)
+                .orElse(ApiResponse.success(null));
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scm-file/service/src/main/java/com/scmcloud/file/controller/FileController.java
+git commit -m "feat(file): add REST controller for file upload"
+```
+
+---
+
+## Task 10: Integration Test
+
+**Files:**
+- Create: `scm-file/service/src/test/java/com/scmcloud/file/integration/FileUploadIntegrationTest.java`
+
+- [ ] **Step 1: Write integration test**
+
+```java
+package com.scmcloud.file.integration;
+
+import com.scmcloud.file.ScmFileApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = ScmFileApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class FileUploadIntegrationTest {
+    
+    @Autowired
+    private TestRestTemplate restTemplate;
+    
+    @Test
+    void shouldUploadFile() {
+        // Given
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("file", new ByteArrayResource("test content".getBytes()) {
+            @Override
+            public String getFilename() {
+                return "test.txt";
+            }
+        });
+        body.add("bizType", "product");
+        body.add("bizId", "123");
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+        
+        HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
+        
+        // When
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "/api/v1/files/upload", request, String.class);
+        
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+    }
+    
+    @Test
+    void shouldCheckFileExistByMd5() {
+        // When
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "/api/v1/files/check/{md5}", String.class, "nonexistent");
+        
+        // Then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+}
+```
+
+- [ ] **Step 2: Run integration test**
+
+```bash
+mvn test -pl scm-file/service -Dtest=FileUploadIntegrationTest -f com.scm.parent/pom.xml
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scm-file/service/src/test/java/com/scmcloud/file/integration/
+git commit -m "test(file): add integration test for file upload"
+```
+
+---
+
+## Summary
+
+| Task | Description | Dependencies |
+|------|-------------|--------------|
+| 1 | Module structure | None |
+| 2 | Database schema | Task 1 |
+| 3 | Entity, Mapper and Converter | Task 2 |
+| 4 | Storage SPI and Enums | Task 1 |
+| 5 | MinIO implementation | Task 3, 4 |
+| 6 | FileMetadata service | Task 3 |
+| 7 | API interfaces (FileQuery, FileManage) | Task 1 |
+| 8 | Upload service | Task 4, 5, 6 |
+| 9 | REST controller | Task 6, 8 |
+| 10 | Integration test | Task 9 |

--- a/docs/superpowers/plans/2026-06-18-scm-message-implementation.md
+++ b/docs/superpowers/plans/2026-06-18-scm-message-implementation.md
@@ -1,0 +1,1136 @@
+# scm-message Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build unified event bus service with Kafka-based domain event publishing, outbox pattern for transactional events, and dead letter queue for failed events.
+
+**Architecture:** New Spring Boot module using Kafka for event streaming, outbox pattern for reliable event delivery, PostgreSQL for event outbox table.
+
+**Tech Stack:** Spring Boot 4.x, Apache Kafka, MyBatis-Plus, Dubbo 3.x
+
+---
+
+## File Structure
+
+```
+scm-message/
+├── pom.xml
+├── api/
+│   ├── pom.xml
+│   └── src/main/java/com/scmcloud/message/api/
+│       ├── EventPublisherApi.java
+│       ├── EventConsumerApi.java
+│       ├── dto/
+│       │   ├── DomainEventDTO.java
+│       │   └── EventOutboxDTO.java
+│       └── enums/
+│           └── OutboxStatus.java
+├── service/
+│   ├── pom.xml
+│   └── src/
+│       ├── main/
+│       │   ├── java/com/scmcloud/message/
+│       │   │   ├── ScmMessageApplication.java
+│       │   │   ├── config/
+│       │   │   │   ├── KafkaConfig.java
+│       │   │   │   └── ProducerConfig.java
+│       │   │   ├── producer/
+│       │   │   │   ├── KafkaEventProducer.java
+│       │   │   │   └── OutboxService.java
+│       │   │   ├── consumer/
+│       │   │   │   ├── ConsumerRegistry.java
+│       │   │   │   └── EventConsumer.java
+│       │   │   ├── deadletter/
+│       │   │   │   ├── DlqService.java
+│       │   │   │   └── DlqRetryScheduler.java
+│       │   │   ├── entity/
+│       │   │   │   └── EventOutbox.java
+│       │   │   ├── event/
+│       │   │   │   ├── DomainEvent.java
+│       │   │   │   ├── OrderCreatedEvent.java
+│       │   │   │   ├── InventoryChangedEvent.java
+│       │   │   │   └── PriceChangedEvent.java
+│       │   │   └── mapper/
+│       │   │       └── EventOutboxMapper.java
+│       │   └── resources/
+│       │       ├── application.yml
+│       │       └── db/migration/
+│       │           └── V1_0_0__create_message_tables.sql
+│       └── test/
+│           └── java/com/scmcloud/message/
+│               ├── producer/
+│               │   └── OutboxServiceTest.java
+│               └── consumer/
+│                   └── ConsumerRegistryTest.java
+```
+
+---
+
+## Task 1: Create Module Structure
+
+**Files:**
+- Create: `scm-message/pom.xml`
+- Create: `scm-message/api/pom.xml`
+- Create: `scm-message/service/pom.xml`
+- Modify: `com.scm.parent/pom.xml`
+
+- [ ] **Step 1: Create parent POM for scm-message**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.scmcloud</groupId>
+    <artifactId>scm-message</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>SCM Message Service</name>
+    <description>Unified event bus service</description>
+
+    <modules>
+        <module>api</module>
+        <module>service</module>
+    </modules>
+</project>
+```
+
+- [ ] **Step 2: Create API module POM**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-message</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scm-message-api</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+- [ ] **Step 3: Create service module POM**
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-message</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scm-message-service</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-message-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-data</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>
+```
+
+- [ ] **Step 4: Add scm-message to parent POM**
+
+Add to `com.scm.parent/pom.xml` in `<modules>`:
+```xml
+<module>../scm-message</module>
+```
+
+- [ ] **Step 5: Verify build**
+
+```bash
+mvn clean install -f scm-message/pom.xml -DskipTests
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scm-message/ com.scm.parent/pom.xml
+git commit -m "feat(message): create scm-message module structure"
+```
+
+---
+
+## Task 2: Create Database Schema
+
+**Files:**
+- Create: `scm-message/service/src/main/resources/db/migration/V1_0_0__create_message_tables.sql`
+
+- [ ] **Step 1: Write migration SQL**
+
+```sql
+-- Event outbox table for transactional event publishing
+CREATE TABLE sys_event_outbox (
+    id              VARCHAR(36) PRIMARY KEY,
+    event_type      VARCHAR(100) NOT NULL,
+    aggregate_type  VARCHAR(100) NOT NULL,
+    aggregate_id    VARCHAR(36) NOT NULL,
+    payload         TEXT NOT NULL,
+    retry_count     INTEGER DEFAULT 0,
+    max_retries     INTEGER DEFAULT 3,
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    error_message   TEXT,
+    tenant_id       BIGINT NOT NULL,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    published_at    TIMESTAMP,
+    next_retry_at   TIMESTAMP
+);
+
+CREATE INDEX idx_outbox_status ON sys_event_outbox(status);
+CREATE INDEX idx_outbox_next_retry ON sys_event_outbox(next_retry_at);
+CREATE INDEX idx_outbox_aggregate ON sys_event_outbox(aggregate_type, aggregate_id);
+
+-- Dead letter queue table
+CREATE TABLE sys_event_dlq (
+    id              VARCHAR(36) PRIMARY KEY,
+    original_event_id VARCHAR(36) NOT NULL,
+    event_type      VARCHAR(100) NOT NULL,
+    aggregate_type  VARCHAR(100) NOT NULL,
+    aggregate_id    VARCHAR(36) NOT NULL,
+    payload         TEXT NOT NULL,
+    error_message   TEXT,
+    error_stack     TEXT,
+    retry_count     INTEGER DEFAULT 0,
+    tenant_id       BIGINT NOT NULL,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    resolved        BOOLEAN DEFAULT FALSE,
+    resolved_at     TIMESTAMP
+);
+
+CREATE INDEX idx_dlq_event_type ON sys_event_dlq(event_type);
+CREATE INDEX idx_dlq_resolved ON sys_event_dlq(resolved);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scm-message/service/src/main/resources/db/migration/
+git commit -m "feat(message): add database schema for event outbox and DLQ"
+```
+
+---
+
+## Task 3: Create Domain Event Interface and Implementations
+
+**Files:**
+- Create: `scm-message/api/src/main/java/com/scmcloud/message/api/dto/DomainEventDTO.java`
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/event/DomainEvent.java`
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/event/OrderCreatedEvent.java`
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/event/InventoryChangedEvent.java`
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/event/PriceChangedEvent.java`
+
+- [ ] **Step 1: Create DomainEventDTO**
+
+```java
+package com.scmcloud.message.api.dto;
+
+import lombok.Data;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Map;
+
+@Data
+public class DomainEventDTO implements Serializable {
+    private String eventId;
+    private String eventType;
+    private String aggregateType;
+    private String aggregateId;
+    private Long tenantId;
+    private Date timestamp;
+    private Map<String, Object> payload;
+}
+```
+
+- [ ] **Step 2: Create DomainEvent interface**
+
+```java
+package com.scmcloud.message.event;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+public interface DomainEvent {
+    String getEventId();
+    String getEventType();
+    String getAggregateType();
+    String getAggregateId();
+    Long getTenantId();
+    Date getTimestamp();
+    Map<String, Object> getPayload();
+    
+    default String generateEventId() {
+        return UUID.randomUUID().toString();
+    }
+}
+```
+
+- [ ] **Step 3: Create OrderCreatedEvent**
+
+```java
+package com.scmcloud.message.event;
+
+import lombok.Builder;
+import lombok.Data;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+public class OrderCreatedEvent implements DomainEvent {
+    private String eventId;
+    private String orderId;
+    private String orderNo;
+    private Long tenantId;
+    private Date timestamp;
+    
+    @Override
+    public String getEventType() {
+        return "ORDER_CREATED";
+    }
+    
+    @Override
+    public String getAggregateType() {
+        return "Order";
+    }
+    
+    @Override
+    public String getAggregateId() {
+        return orderId;
+    }
+    
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("orderId", orderId);
+        payload.put("orderNo", orderNo);
+        return payload;
+    }
+    
+    public static OrderCreatedEvent of(String orderId, String orderNo, Long tenantId) {
+        return OrderCreatedEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .orderId(orderId)
+                .orderNo(orderNo)
+                .tenantId(tenantId)
+                .timestamp(new Date())
+                .build();
+    }
+}
+```
+
+- [ ] **Step 4: Create InventoryChangedEvent**
+
+```java
+package com.scmcloud.message.event;
+
+import lombok.Builder;
+import lombok.Data;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+public class InventoryChangedEvent implements DomainEvent {
+    private String eventId;
+    private String skuId;
+    private String warehouseId;
+    private Integer quantityChange;
+    private Integer newQuantity;
+    private String changeType;
+    private Long tenantId;
+    private Date timestamp;
+    
+    @Override
+    public String getEventType() {
+        return "INVENTORY_CHANGED";
+    }
+    
+    @Override
+    public String getAggregateType() {
+        return "Inventory";
+    }
+    
+    @Override
+    public String getAggregateId() {
+        return skuId + ":" + warehouseId;
+    }
+    
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("skuId", skuId);
+        payload.put("warehouseId", warehouseId);
+        payload.put("quantityChange", quantityChange);
+        payload.put("newQuantity", newQuantity);
+        payload.put("changeType", changeType);
+        return payload;
+    }
+    
+    public static InventoryChangedEvent of(String skuId, String warehouseId, 
+                                            Integer quantityChange, Integer newQuantity,
+                                            String changeType, Long tenantId) {
+        return InventoryChangedEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .skuId(skuId)
+                .warehouseId(warehouseId)
+                .quantityChange(quantityChange)
+                .newQuantity(newQuantity)
+                .changeType(changeType)
+                .tenantId(tenantId)
+                .timestamp(new Date())
+                .build();
+    }
+}
+```
+
+- [ ] **Step 5: Create PriceChangedEvent**
+
+```java
+package com.scmcloud.message.event;
+
+import lombok.Builder;
+import lombok.Data;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+public class PriceChangedEvent implements DomainEvent {
+    private String eventId;
+    private String productId;
+    private String skuId;
+    private BigDecimal oldPrice;
+    private BigDecimal newPrice;
+    private String priceListId;
+    private Long tenantId;
+    private Date timestamp;
+    
+    @Override
+    public String getEventType() {
+        return "PRICE_CHANGED";
+    }
+    
+    @Override
+    public String getAggregateType() {
+        return "Price";
+    }
+    
+    @Override
+    public String getAggregateId() {
+        return productId + ":" + skuId;
+    }
+    
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("productId", productId);
+        payload.put("skuId", skuId);
+        payload.put("oldPrice", oldPrice);
+        payload.put("newPrice", newPrice);
+        payload.put("priceListId", priceListId);
+        return payload;
+    }
+    
+    public static PriceChangedEvent of(String productId, String skuId, 
+                                        BigDecimal oldPrice, BigDecimal newPrice,
+                                        String priceListId, Long tenantId) {
+        return PriceChangedEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .productId(productId)
+                .skuId(skuId)
+                .oldPrice(oldPrice)
+                .newPrice(newPrice)
+                .priceListId(priceListId)
+                .tenantId(tenantId)
+                .timestamp(new Date())
+                .build();
+    }
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scm-message/api/src/main/java/com/scmcloud/message/api/dto/
+git add scm-message/service/src/main/java/com/scmcloud/message/event/
+git commit -m "feat(message): add domain event interface and implementations"
+```
+
+---
+
+## Task 4: Create Outbox Entity and Mapper
+
+**Files:**
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/entity/EventOutbox.java`
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/mapper/EventOutboxMapper.java`
+- Create: `scm-message/api/src/main/java/com/scmcloud/message/api/enums/OutboxStatus.java`
+
+- [ ] **Step 1: Create OutboxStatus enum**
+
+```java
+package com.scmcloud.message.api.enums;
+
+public enum OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED,
+    RETRYING
+}
+```
+
+- [ ] **Step 2: Create EventOutbox entity**
+
+```java
+package com.scmcloud.message.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import java.util.Date;
+
+@Data
+@TableName("sys_event_outbox")
+public class EventOutbox {
+    @TableId(type = IdType.ASSIGN_UUID)
+    private String id;
+    private String eventType;
+    private String aggregateType;
+    private String aggregateId;
+    private String payload;
+    private Integer retryCount;
+    private Integer maxRetries;
+    private String status;
+    private String errorMessage;
+    private Long tenantId;
+    private Date createTime;
+    private Date publishedAt;
+    private Date nextRetryAt;
+}
+```
+
+- [ ] **Step 3: Create EventOutboxMapper**
+
+```java
+package com.scmcloud.message.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.scmcloud.message.entity.EventOutbox;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import java.util.Date;
+import java.util.List;
+
+@Mapper
+public interface EventOutboxMapper extends BaseMapper<EventOutbox> {
+    
+    @Select("SELECT * FROM sys_event_outbox WHERE status = 'PENDING' AND next_retry_at <= #{now} LIMIT #{limit}")
+    List<EventOutbox> findPendingEvents(@Param("now") Date now, @Param("limit") int limit);
+    
+    @Select("SELECT * FROM sys_event_outbox WHERE status = 'RETRYING' AND next_retry_at <= #{now} LIMIT #{limit}")
+    List<EventOutbox> findRetryingEvents(@Param("now") Date now, @Param("limit") int limit);
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scm-message/api/src/main/java/com/scmcloud/message/api/enums/
+git add scm-message/service/src/main/java/com/scmcloud/message/entity/
+git add scm-message/service/src/main/java/com/scmcloud/message/mapper/
+git commit -m "feat(message): add outbox entity and mapper"
+```
+
+---
+
+## Task 5: Create Outbox Service
+
+**Files:**
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxService.java`
+
+- [ ] **Step 1: Write test for OutboxService**
+
+```java
+package com.scmcloud.message.producer;
+
+import com.scmcloud.message.entity.EventOutbox;
+import com.scmcloud.message.event.DomainEvent;
+import com.scmcloud.message.event.OrderCreatedEvent;
+import com.scmcloud.message.mapper.EventOutboxMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxServiceTest {
+    
+    @Mock
+    private EventOutboxMapper mapper;
+    
+    @InjectMocks
+    private OutboxService outboxService;
+    
+    @Test
+    void shouldSaveEventToOutbox() {
+        // Given
+        DomainEvent event = OrderCreatedEvent.of("order-1", "ORD001", 1L);
+        when(mapper.insert(any())).thenReturn(1);
+        
+        // When
+        EventOutbox result = outboxService.save(event);
+        
+        // Then
+        assertNotNull(result);
+        assertEquals("ORDER_CREATED", result.getEventType());
+        assertEquals("PENDING", result.getStatus());
+        verify(mapper).insert(any());
+    }
+    
+    @Test
+    void shouldMarkAsPublished() {
+        // Given
+        String eventId = "event-1";
+        EventOutbox outbox = new EventOutbox();
+        outbox.setId(eventId);
+        outbox.setStatus("PENDING");
+        when(mapper.selectById(eventId)).thenReturn(outbox);
+        when(mapper.updateById(any())).thenReturn(1);
+        
+        // When
+        outboxService.markAsPublished(eventId);
+        
+        // Then
+        assertEquals("PUBLISHED", outbox.getStatus());
+        assertNotNull(outbox.getPublishedAt());
+        verify(mapper).updateById(outbox);
+    }
+}
+```
+
+- [ ] **Step 2: Implement OutboxService**
+
+```java
+package com.scmcloud.message.producer;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.scmcloud.message.entity.EventOutbox;
+import com.scmcloud.message.event.DomainEvent;
+import com.scmcloud.message.mapper.EventOutboxMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
+@Service
+public class OutboxService extends ServiceImpl<EventOutboxMapper, EventOutbox> {
+    
+    private final ObjectMapper objectMapper;
+    
+    public OutboxService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+    
+    public EventOutbox save(DomainEvent event) {
+        try {
+            EventOutbox outbox = new EventOutbox();
+            outbox.setId(event.getEventId());
+            outbox.setEventType(event.getEventType());
+            outbox.setAggregateType(event.getAggregateType());
+            outbox.setAggregateId(event.getAggregateId());
+            outbox.setPayload(objectMapper.writeValueAsString(event.getPayload()));
+            outbox.setRetryCount(0);
+            outbox.setMaxRetries(3);
+            outbox.setStatus("PENDING");
+            outbox.setTenantId(event.getTenantId());
+            outbox.setCreateTime(new Date());
+            outbox.setNextRetryAt(new Date());
+            
+            save(outbox);
+            return outbox;
+        } catch (Exception e) {
+            log.error("Failed to save event to outbox", e);
+            throw new RuntimeException("Failed to save event", e);
+        }
+    }
+    
+    public void markAsPublished(String eventId) {
+        EventOutbox outbox = getById(eventId);
+        if (outbox != null) {
+            outbox.setStatus("PUBLISHED");
+            outbox.setPublishedAt(new Date());
+            updateById(outbox);
+        }
+    }
+    
+    public void markAsFailed(String eventId, String errorMessage) {
+        EventOutbox outbox = getById(eventId);
+        if (outbox != null) {
+            outbox.setRetryCount(outbox.getRetryCount() + 1);
+            outbox.setErrorMessage(errorMessage);
+            
+            if (outbox.getRetryCount() >= outbox.getMaxRetries()) {
+                outbox.setStatus("FAILED");
+            } else {
+                outbox.setStatus("RETRYING");
+                // Exponential backoff: 1min, 5min, 15min
+                long[] backoff = {60000, 300000, 900000};
+                long delay = backoff[Math.min(outbox.getRetryCount(), backoff.length - 1)];
+                outbox.setNextRetryAt(new Date(System.currentTimeMillis() + delay));
+            }
+            
+            updateById(outbox);
+        }
+    }
+    
+    public List<EventOutbox> findPendingEvents(int limit) {
+        return baseMapper.findPendingEvents(new Date(), limit);
+    }
+    
+    public List<EventOutbox> findRetryingEvents(int limit) {
+        return baseMapper.findRetryingEvents(new Date(), limit);
+    }
+}
+```
+
+- [ ] **Step 3: Run test**
+
+```bash
+mvn test -pl scm-message/service -Dtest=OutboxServiceTest -f com.scm.parent/pom.xml
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxService.java
+git commit -m "feat(message): implement outbox service"
+```
+
+---
+
+## Task 6: Create Kafka Event Producer
+
+**Files:**
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/producer/KafkaEventProducer.java`
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/config/KafkaConfig.java`
+
+- [ ] **Step 1: Create KafkaConfig**
+
+```java
+package com.scmcloud.message.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+    
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+    
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.ACKS_CONFIG, "all");
+        config.put(ProducerConfig.RETRIES_CONFIG, 3);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+    
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}
+```
+
+- [ ] **Step 2: Create KafkaEventProducer**
+
+```java
+package com.scmcloud.message.producer;
+
+import com.scmcloud.message.event.DomainEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaEventProducer {
+    
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    
+    private static final String TOPIC_PREFIX = "scm.";
+    
+    public CompletableFuture<SendResult<String, String>> send(DomainEvent event) {
+        String topic = TOPIC_PREFIX + event.getAggregateType().toLowerCase() + ".events";
+        String key = event.getAggregateId();
+        
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            
+            CompletableFuture<SendResult<String, String>> future = 
+                    kafkaTemplate.send(topic, key, payload);
+            
+            future.whenComplete((result, ex) -> {
+                if (ex == null) {
+                    log.info("Event sent successfully: topic={}, key={}, eventType={}", 
+                            topic, key, event.getEventType());
+                } else {
+                    log.error("Failed to send event: topic={}, key={}, eventType={}", 
+                            topic, key, event.getEventType(), ex);
+                }
+            });
+            
+            return future;
+        } catch (Exception e) {
+            log.error("Failed to serialize event", e);
+            throw new RuntimeException("Failed to serialize event", e);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scm-message/service/src/main/java/com/scmcloud/message/producer/KafkaEventProducer.java
+git add scm-message/service/src/main/java/com/scmcloud/message/config/KafkaConfig.java
+git commit -m "feat(message): add Kafka event producer"
+```
+
+---
+
+## Task 7: Create Outbox Publisher Scheduler
+
+**Files:**
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxPublisher.java`
+
+- [ ] **Step 1: Implement OutboxPublisher**
+
+```java
+package com.scmcloud.message.producer;
+
+import com.scmcloud.message.entity.EventOutbox;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxPublisher {
+    
+    private final OutboxService outboxService;
+    private final KafkaEventProducer kafkaEventProducer;
+    
+    @Scheduled(fixedDelay = 5000) // Every 5 seconds
+    public void publishPendingEvents() {
+        List<EventOutbox> pendingEvents = outboxService.findPendingEvents(100);
+        
+        for (EventOutbox event : pendingEvents) {
+            publishEvent(event);
+        }
+    }
+    
+    @Scheduled(fixedDelay = 30000) // Every 30 seconds
+    public void publishRetryingEvents() {
+        List<EventOutbox> retryingEvents = outboxService.findRetryingEvents(50);
+        
+        for (EventOutbox event : retryingEvents) {
+            publishEvent(event);
+        }
+    }
+    
+    private void publishEvent(EventOutbox event) {
+        try {
+            // Convert outbox to domain event
+            DomainEvent domainEvent = convertToDomainEvent(event);
+            
+            // Send to Kafka
+            kafkaEventProducer.send(domainEvent)
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            outboxService.markAsPublished(event.getId());
+                        } else {
+                            outboxService.markAsFailed(event.getId(), ex.getMessage());
+                        }
+                    });
+        } catch (Exception e) {
+            log.error("Failed to publish event: {}", event.getId(), e);
+            outboxService.markAsFailed(event.getId(), e.getMessage());
+        }
+    }
+    
+    private DomainEvent convertToDomainEvent(EventOutbox outbox) {
+        // Simple conversion - in production, use event registry
+        return new DomainEvent() {
+            @Override
+            public String getEventId() { return outbox.getId(); }
+            @Override
+            public String getEventType() { return outbox.getEventType(); }
+            @Override
+            public String getAggregateType() { return outbox.getAggregateType(); }
+            @Override
+            public String getAggregateId() { return outbox.getAggregateId(); }
+            @Override
+            public Long getTenantId() { return outbox.getTenantId(); }
+            @Override
+            public java.util.Date getTimestamp() { return outbox.getCreateTime(); }
+            @Override
+            public java.util.Map<String, Object> getPayload() { return java.util.Collections.emptyMap(); }
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxPublisher.java
+git commit -m "feat(message): add outbox publisher scheduler"
+```
+
+---
+
+## Task 8: Create API Interface
+
+**Files:**
+- Create: `scm-message/api/src/main/java/com/scmcloud/message/api/EventPublisherApi.java`
+
+- [ ] **Step 1: Create EventPublisherApi**
+
+```java
+package com.scmcloud.message.api;
+
+import com.scmcloud.message.api.dto.DomainEventDTO;
+
+public interface EventPublisherApi {
+    
+    /**
+     * Publish event to outbox (transactional)
+     */
+    void publish(DomainEventDTO event);
+    
+    /**
+     * Publish event directly to Kafka (non-transactional)
+     */
+    void publishDirect(DomainEventDTO event);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scm-message/api/src/main/java/com/scmcloud/message/api/EventPublisherApi.java
+git commit -m "feat(message): add EventPublisher API interface"
+```
+
+---
+
+## Task 9: Create Application Entry Point
+
+**Files:**
+- Create: `scm-message/service/src/main/java/com/scmcloud/message/ScmMessageApplication.java`
+- Create: `scm-message/service/src/main/resources/application.yml`
+
+- [ ] **Step 1: Create ScmMessageApplication**
+
+```java
+package com.scmcloud.message;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class ScmMessageApplication {
+    
+    public static void main(String[] args) {
+        SpringApplication.run(ScmMessageApplication.class, args);
+    }
+}
+```
+
+- [ ] **Step 2: Create application.yml**
+
+```yaml
+server:
+  port: 8209
+
+spring:
+  application:
+    name: scm-message
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/db_system
+    username: ${DB_USERNAME:admin}
+    password: ${DB_PASSWORD:admin123}
+  kafka:
+    bootstrap-servers: ${KAFKA_SERVERS:localhost:9092}
+
+mybatis-plus:
+  mapper-locations: classpath*:mapper/**/*.xml
+  configuration:
+    map-underscore-to-camel-case: true
+
+logging:
+  level:
+    com.scmcloud.message: DEBUG
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scm-message/service/src/main/java/com/scmcloud/message/ScmMessageApplication.java
+git add scm-message/service/src/main/resources/application.yml
+git commit -m "feat(message): add application entry point and config"
+```
+
+---
+
+## Task 10: Integration Test
+
+**Files:**
+- Create: `scm-message/service/src/test/java/com/scmcloud/message/integration/MessageIntegrationTest.java`
+
+- [ ] **Step 1: Write integration test**
+
+```java
+package com.scmcloud.message.integration;
+
+import com.scmcloud.message.ScmMessageApplication;
+import com.scmcloud.message.event.DomainEvent;
+import com.scmcloud.message.event.OrderCreatedEvent;
+import com.scmcloud.message.producer.OutboxService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = ScmMessageApplication.class)
+class MessageIntegrationTest {
+    
+    @Autowired
+    private OutboxService outboxService;
+    
+    @Test
+    void shouldSaveEventToOutbox() {
+        // Given
+        DomainEvent event = OrderCreatedEvent.of("order-1", "ORD001", 1L);
+        
+        // When
+        var result = outboxService.save(event);
+        
+        // Then
+        assertNotNull(result);
+        assertEquals("ORDER_CREATED", result.getEventType());
+        assertEquals("PENDING", result.getStatus());
+    }
+}
+```
+
+- [ ] **Step 2: Run integration test**
+
+```bash
+mvn test -pl scm-message/service -Dtest=MessageIntegrationTest -f com.scm.parent/pom.xml
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scm-message/service/src/test/java/com/scmcloud/message/integration/
+git commit -m "test(message): add integration test for message service"
+```
+
+---
+
+## Summary
+
+| Task | Description | Dependencies |
+|------|-------------|--------------|
+| 1 | Module structure | None |
+| 2 | Database schema | Task 1 |
+| 3 | Domain events | Task 1 |
+| 4 | Outbox entity/mapper | Task 2 |
+| 5 | Outbox service | Task 4 |
+| 6 | Kafka producer | Task 3 |
+| 7 | Outbox publisher | Task 5, 6 |
+| 8 | API interface | Task 1 |
+| 9 | Application entry | Task 7 |
+| 10 | Integration test | Task 9 |

--- a/docs/superpowers/plans/2026-06-18-storage-spi-enums.md
+++ b/docs/superpowers/plans/2026-06-18-storage-spi-enums.md
@@ -1,0 +1,214 @@
+# Storage SPI and Enums Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the storage abstraction layer with SPI pattern for the scm-file module, enabling multiple storage backends (MinIO, OSS, S3).
+
+**Architecture:** Implement a factory pattern with StorageEngine SPI interface. Each storage backend implements the interface and declares its supported StorageType. The StorageFactory manages engine registration and retrieval.
+
+**Tech Stack:** Java, Spring Boot, Lombok, JUnit 5, Mockito
+
+---
+
+## File Structure
+
+- `scm-file/api/src/main/java/com/scmcloud/file/api/enums/StorageType.java` - Storage type enum
+- `scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageEngine.java` - Storage SPI interface
+- `scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageFactory.java` - Factory for managing engines
+- `scm-file/service/src/test/java/com/scmcloud/file/service/storage/StorageFactoryTest.java` - Unit tests
+
+---
+
+### Task 1: Create StorageType Enum
+
+**Files:**
+- Create: `scm-file/api/src/main/java/com/scmcloud/file/api/enums/StorageType.java`
+
+- [ ] **Step 1: Create StorageType enum**
+
+```java
+package com.scmcloud.file.api.enums;
+
+public enum StorageType {
+    MINIO,
+    OSS,
+    S3
+}
+```
+
+- [ ] **Step 2: Verify file created**
+
+Run: `ls scm-file/api/src/main/java/com/scmcloud/file/api/enums/`
+Expected: StorageType.java exists
+
+---
+
+### Task 2: Create StorageEngine Interface
+
+**Files:**
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageEngine.java`
+
+- [ ] **Step 1: Create StorageEngine interface**
+
+```java
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import com.scmcloud.file.entity.FileMetadata;
+import java.io.InputStream;
+import java.time.Duration;
+
+public interface StorageEngine {
+    
+    FileMetadata upload(byte[] fileBytes, String fileName, String contentType, Long tenantId);
+    
+    InputStream download(String fileKey);
+    
+    String generatePresignedUrl(String fileKey, Duration expiry);
+    
+    void delete(String fileKey);
+    
+    boolean exists(String fileKey);
+    
+    StorageType support();
+}
+```
+
+- [ ] **Step 2: Verify file created**
+
+Run: `ls scm-file/service/src/main/java/com/scmcloud/file/service/storage/`
+Expected: StorageEngine.java exists
+
+---
+
+### Task 3: Create StorageFactory
+
+**Files:**
+- Create: `scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageFactory.java`
+
+- [ ] **Step 1: Create StorageFactory class**
+
+```java
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class StorageFactory {
+    
+    private final List<StorageEngine> engineList;
+    private final Map<StorageType, StorageEngine> engineMap = new EnumMap<>(StorageType.class);
+    
+    public StorageFactory(List<StorageEngine> engineList) {
+        this.engineList = engineList;
+    }
+    
+    @PostConstruct
+    public void init() {
+        for (StorageEngine engine : engineList) {
+            StorageType type = engine.support();
+            engineMap.put(type, engine);
+            log.info("Registered storage engine: {} -> {}", type, engine.getClass().getSimpleName());
+        }
+    }
+    
+    public StorageEngine getEngine(StorageType type) {
+        StorageEngine engine = engineMap.get(type);
+        if (engine == null) {
+            throw new IllegalArgumentException("No storage engine found for type: " + type);
+        }
+        return engine;
+    }
+    
+    public StorageEngine getDefaultEngine() {
+        return getEngine(StorageType.MINIO);
+    }
+}
+```
+
+- [ ] **Step 2: Verify file created**
+
+Run: `ls scm-file/service/src/main/java/com/scmcloud/file/service/storage/`
+Expected: StorageFactory.java exists
+
+---
+
+### Task 4: Write and Run StorageFactory Test
+
+**Files:**
+- Create: `scm-file/service/src/test/java/com/scmcloud/file/service/storage/StorageFactoryTest.java`
+
+- [ ] **Step 1: Create test file**
+
+```java
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StorageFactoryTest {
+    
+    @Test
+    void shouldGetEngineByType() {
+        // Given
+        MinioStorageEngine minioEngine = mock(MinioStorageEngine.class);
+        when(minioEngine.support()).thenReturn(StorageType.MINIO);
+        
+        StorageFactory factory = new StorageFactory(List.of(minioEngine));
+        factory.init();
+        
+        // When
+        StorageEngine result = factory.getEngine(StorageType.MINIO);
+        
+        // Then
+        assertEquals(minioEngine, result);
+    }
+    
+    @Test
+    void shouldThrowExceptionForUnsupportedType() {
+        // Given
+        StorageFactory factory = new StorageFactory(List.of());
+        factory.init();
+        
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> factory.getEngine(StorageType.MINIO));
+    }
+}
+```
+
+- [ ] **Step 2: Run test**
+
+Run: `mvn test -pl scm-file/service -Dtest=StorageFactoryTest -f com.scm.parent/pom.xml`
+Expected: Tests pass
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scm-file/service/src/main/java/com/scmcloud/file/service/storage/
+git add scm-file/api/src/main/java/com/scmcloud/file/api/enums/StorageType.java
+git commit -m "feat(file): add storage SPI interface and factory"
+```
+
+---
+
+## Verification
+
+After completing all tasks:
+1. Verify all files exist in correct locations
+2. Run tests to ensure they pass
+3. Check that StorageEngine interface uses byte[] for uploads (not InputStream)
+4. Verify StorageFactory uses EnumMap for type-safe storage
+5. Confirm test coverage for both successful and error cases

--- a/scm-file/api/pom.xml
+++ b/scm-file/api/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-file</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scm-file-api</artifactId>
+    <packaging>jar</packaging>
+    <name>SCM File API</name>
+    <description>File service Dubbo RPC API definitions</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-core</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/scm-file/api/src/main/java/com/scmcloud/file/api/FileManageApi.java
+++ b/scm-file/api/src/main/java/com/scmcloud/file/api/FileManageApi.java
@@ -1,0 +1,28 @@
+package com.scmcloud.file.api;
+
+/**
+ * 文件管理 Dubbo 接口
+ *
+ * @author SCM Platform Team
+ * @since 2026-06-18
+ */
+public interface FileManageApi {
+
+    /**
+     * 删除文件
+     *
+     * @param id 文件ID
+     * @param tenantId 租户ID
+     */
+    void delete(String id, Long tenantId);
+
+    /**
+     * 更新文件业务关联
+     *
+     * @param id 文件ID
+     * @param bizType 业务类型
+     * @param bizId 业务ID
+     * @param tenantId 租户ID
+     */
+    void updateBizAssociation(String id, String bizType, String bizId, Long tenantId);
+}

--- a/scm-file/api/src/main/java/com/scmcloud/file/api/FileQueryApi.java
+++ b/scm-file/api/src/main/java/com/scmcloud/file/api/FileQueryApi.java
@@ -1,0 +1,50 @@
+package com.scmcloud.file.api;
+
+import com.scmcloud.file.api.dto.FileMetadataDTO;
+import java.util.List;
+
+/**
+ * 文件查询 Dubbo 接口
+ *
+ * @author SCM Platform Team
+ * @since 2026-06-18
+ */
+public interface FileQueryApi {
+
+    /**
+     * 根据ID查询文件元数据
+     *
+     * @param id 文件ID
+     * @param tenantId 租户ID
+     * @return 文件元数据DTO
+     */
+    FileMetadataDTO getById(String id, Long tenantId);
+
+    /**
+     * 根据MD5查询文件元数据
+     *
+     * @param md5 文件MD5值
+     * @param tenantId 租户ID
+     * @return 文件元数据DTO
+     */
+    FileMetadataDTO getByMd5(String md5, Long tenantId);
+
+    /**
+     * 根据业务关联查询文件列表
+     *
+     * @param bizType 业务类型
+     * @param bizId 业务ID
+     * @param tenantId 租户ID
+     * @return 文件元数据DTO列表
+     */
+    List<FileMetadataDTO> getByBizId(String bizType, String bizId, Long tenantId);
+
+    /**
+     * 生成文件预签名URL
+     *
+     * @param fileKey 文件存储key
+     * @param tenantId 租户ID
+     * @return 预签名URL
+     */
+    String generatePresignedUrl(String fileKey, Long tenantId);
+}

--- a/scm-file/api/src/main/java/com/scmcloud/file/api/dto/FileMetadataDTO.java
+++ b/scm-file/api/src/main/java/com/scmcloud/file/api/dto/FileMetadataDTO.java
@@ -1,0 +1,25 @@
+package com.scmcloud.file.api.dto;
+
+import lombok.Data;
+import java.util.Date;
+
+@Data
+public class FileMetadataDTO {
+    private String id;
+    private String originalName;
+    private String storageKey;
+    private String contentType;
+    private Long fileSize;
+    private String storageEngine;
+    private String md5;
+    private Integer version;
+    private String bizType;
+    private String bizId;
+    private String status;
+    private Integer refCount;
+    private Long tenantId;
+    private Long createBy;
+    private Long updateBy;
+    private Date createTime;
+    private Date updateTime;
+}

--- a/scm-file/api/src/main/java/com/scmcloud/file/api/enums/StorageType.java
+++ b/scm-file/api/src/main/java/com/scmcloud/file/api/enums/StorageType.java
@@ -1,0 +1,7 @@
+package com.scmcloud.file.api.enums;
+
+public enum StorageType {
+    MINIO,
+    OSS,
+    S3
+}

--- a/scm-file/api/src/main/java/com/scmcloud/file/api/enums/UploadTaskStatus.java
+++ b/scm-file/api/src/main/java/com/scmcloud/file/api/enums/UploadTaskStatus.java
@@ -1,0 +1,27 @@
+package com.scmcloud.file.api.enums;
+
+public enum UploadTaskStatus {
+    PENDING(0),
+    UPLOADING(1),
+    COMPLETED(2),
+    FAILED(3);
+
+    private final int code;
+
+    UploadTaskStatus(int code) {
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public static UploadTaskStatus fromCode(int code) {
+        for (UploadTaskStatus status : values()) {
+            if (status.code == code) {
+                return status;
+            }
+        }
+        throw new IllegalArgumentException("Unknown UploadTaskStatus code: " + code);
+    }
+}

--- a/scm-file/api/src/main/java/com/scmcloud/file/api/enums/UploadTaskStatus.java
+++ b/scm-file/api/src/main/java/com/scmcloud/file/api/enums/UploadTaskStatus.java
@@ -1,10 +1,11 @@
 package com.scmcloud.file.api.enums;
 
 public enum UploadTaskStatus {
-    PENDING(0),
-    UPLOADING(1),
-    COMPLETED(2),
-    FAILED(3);
+    INIT(0),
+    PENDING(1),
+    UPLOADING(2),
+    COMPLETED(3),
+    FAILED(4);
 
     private final int code;
 

--- a/scm-file/api/src/main/java/com/scmcloud/file/api/enums/UploadTaskStatus.java
+++ b/scm-file/api/src/main/java/com/scmcloud/file/api/enums/UploadTaskStatus.java
@@ -1,28 +1,21 @@
 package com.scmcloud.file.api.enums;
 
+import com.baomidou.mybatisplus.annotation.EnumValue;
+import lombok.Getter;
+
+@Getter
 public enum UploadTaskStatus {
-    INIT(0),
-    PENDING(1),
-    UPLOADING(2),
-    COMPLETED(3),
-    FAILED(4);
+    INIT(0, "Initial"),
+    UPLOADING(1, "Uploading"),
+    SUCCESS(2, "Success"),
+    FAILED(3, "Failed");
 
+    @EnumValue
     private final int code;
+    private final String desc;
 
-    UploadTaskStatus(int code) {
+    UploadTaskStatus(int code, String desc) {
         this.code = code;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    public static UploadTaskStatus fromCode(int code) {
-        for (UploadTaskStatus status : values()) {
-            if (status.code == code) {
-                return status;
-            }
-        }
-        throw new IllegalArgumentException("Unknown UploadTaskStatus code: " + code);
+        this.desc = desc;
     }
 }

--- a/scm-file/pom.xml
+++ b/scm-file/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-platform</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../com.scm.parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>scm-file</artifactId>
+    <packaging>pom</packaging>
+
+    <name>SCM File Service</name>
+    <description>Unified file storage service</description>
+
+    <modules>
+        <module>api</module>
+        <module>service</module>
+    </modules>
+</project>

--- a/scm-file/service/pom.xml
+++ b/scm-file/service/pom.xml
@@ -51,6 +51,17 @@
             <version>2.25.0</version>
         </dependency>
         <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>1.6.3</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <version>1.6.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/scm-file/service/pom.xml
+++ b/scm-file/service/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-file</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scm-file-service</artifactId>
+    <packaging>jar</packaging>
+    <name>SCM File Service Implementation</name>
+    <description>File storage service with MinIO/OSS/S3 support</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-file-api</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-data</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-web</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.minio</groupId>
+            <artifactId>minio</artifactId>
+            <version>8.5.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.aliyun.oss</groupId>
+            <artifactId>aliyun-sdk-oss</artifactId>
+            <version>3.17.4</version>
+        </dependency>
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.25.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/scm-file/service/src/main/java/com/scmcloud/file/ScmFileApplication.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/ScmFileApplication.java
@@ -1,0 +1,14 @@
+package com.scmcloud.file;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.ComponentScan;
+
+@SpringBootApplication
+@ComponentScan(basePackages = "com.scmcloud")
+public class ScmFileApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ScmFileApplication.class, args);
+    }
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/ScmFileApplication.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/ScmFileApplication.java
@@ -2,10 +2,8 @@ package com.scmcloud.file;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
-@ComponentScan(basePackages = "com.scmcloud")
 public class ScmFileApplication {
 
     public static void main(String[] args) {

--- a/scm-file/service/src/main/java/com/scmcloud/file/config/StorageConfig.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/config/StorageConfig.java
@@ -1,0 +1,16 @@
+package com.scmcloud.file.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Data
+@Component
+@ConfigurationProperties(prefix = "storage.minio")
+public class StorageConfig {
+    private String endpoint;
+    private String accessKey;
+    private String secretKey;
+    private String bucketName;
+    private boolean createBucket = true;
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/controller/FileController.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/controller/FileController.java
@@ -1,0 +1,48 @@
+package com.scmcloud.file.controller;
+
+import com.scmcloud.common.response.ApiResponse;
+import com.scmcloud.file.api.dto.FileMetadataDTO;
+import com.scmcloud.file.convert.FileMetadataConvert;
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.service.upload.InstantUploadService;
+import com.scmcloud.file.service.upload.UploadService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@RequiredArgsConstructor
+public class FileController {
+    
+    private final UploadService uploadService;
+    private final InstantUploadService instantUploadService;
+    private final FileMetadataConvert fileMetadataConvert;
+    
+    @PostMapping("/upload")
+    public ApiResponse<FileMetadataDTO> upload(@RequestParam("file") MultipartFile file,
+                                                @RequestParam(value = "bizType", required = false) String bizType,
+                                                @RequestParam(value = "bizId", required = false) String bizId) {
+        try {
+            FileMetadata metadata = uploadService.upload(
+                    file.getBytes(),
+                    file.getOriginalFilename(),
+                    file.getContentType(),
+                    bizType,
+                    bizId,
+                    1L // TODO: get from TenantContextHolder
+            );
+            return ApiResponse.success(fileMetadataConvert.toDTO(metadata));
+        } catch (Exception e) {
+            return ApiResponse.fail(500, "Upload failed: " + e.getMessage());
+        }
+    }
+    
+    @GetMapping("/check/{md5}")
+    public ApiResponse<FileMetadataDTO> checkExist(@PathVariable String md5) {
+        return instantUploadService.checkExist(md5, 1L) // TODO: get from TenantContextHolder
+                .map(fileMetadataConvert::toDTO)
+                .map(ApiResponse::success)
+                .orElse(ApiResponse.success(null));
+    }
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/convert/FileMetadataConvert.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/convert/FileMetadataConvert.java
@@ -1,0 +1,13 @@
+package com.scmcloud.file.convert;
+
+import com.scmcloud.file.api.dto.FileMetadataDTO;
+import com.scmcloud.file.entity.FileMetadata;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface FileMetadataConvert {
+    
+    FileMetadataDTO toDTO(FileMetadata entity);
+    
+    FileMetadata toEntity(FileMetadataDTO dto);
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/entity/FileMetadata.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/entity/FileMetadata.java
@@ -1,0 +1,30 @@
+package com.scmcloud.file.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import java.util.Date;
+
+@Data
+@TableName("sys_file_metadata")
+public class FileMetadata {
+    @TableId(type = IdType.ASSIGN_UUID)
+    private String id;
+    private String originalName;
+    private String storageKey;
+    private String contentType;
+    private Long fileSize;
+    private String storageEngine;
+    private String md5;
+    private Integer version;
+    private String bizType;
+    private String bizId;
+    private String status;
+    private Integer refCount;
+    private Long tenantId;
+    private Long createBy;
+    private Long updateBy;
+    private Date createTime;
+    private Date updateTime;
+    @TableLogic
+    private Integer deleted;
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/entity/FileVersion.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/entity/FileVersion.java
@@ -1,0 +1,20 @@
+package com.scmcloud.file.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import java.util.Date;
+
+@Data
+@TableName("sys_file_version")
+public class FileVersion {
+    @TableId(type = IdType.ASSIGN_UUID)
+    private String id;
+    private String fileId;
+    private Integer version;
+    private String storageKey;
+    private Long fileSize;
+    private String md5;
+    private Long createBy;
+    private Date createTime;
+    private Long tenantId;
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/entity/UploadTask.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/entity/UploadTask.java
@@ -1,0 +1,29 @@
+package com.scmcloud.file.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import com.scmcloud.file.api.enums.UploadTaskStatus;
+import lombok.Data;
+import java.util.Date;
+
+@Data
+@TableName("sys_upload_task")
+public class UploadTask {
+    @TableId(type = IdType.ASSIGN_UUID)
+    private String id;
+    private String fileName;
+    private Long fileSize;
+    private String md5;
+    private String storageKey;
+    private Integer totalParts;
+    private Integer completedParts;
+    private UploadTaskStatus status;
+    private String uploadId;
+    private Long tenantId;
+    private Long createBy;
+    private Date createTime;
+    private Date updateTime;
+    @TableLogic
+    private Integer deleted;
+    @Version
+    private Integer lockVersion;
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/mapper/FileMetadataMapper.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/mapper/FileMetadataMapper.java
@@ -1,0 +1,9 @@
+package com.scmcloud.file.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.scmcloud.file.entity.FileMetadata;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface FileMetadataMapper extends BaseMapper<FileMetadata> {
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/mapper/FileVersionMapper.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/mapper/FileVersionMapper.java
@@ -1,0 +1,9 @@
+package com.scmcloud.file.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.scmcloud.file.entity.FileVersion;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface FileVersionMapper extends BaseMapper<FileVersion> {
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/mapper/UploadTaskMapper.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/mapper/UploadTaskMapper.java
@@ -1,0 +1,9 @@
+package com.scmcloud.file.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.scmcloud.file.entity.UploadTask;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface UploadTaskMapper extends BaseMapper<UploadTask> {
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/service/metadata/FileMetadataService.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/service/metadata/FileMetadataService.java
@@ -1,0 +1,35 @@
+package com.scmcloud.file.service.metadata;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.mapper.FileMetadataMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class FileMetadataService extends ServiceImpl<FileMetadataMapper, FileMetadata> {
+    
+    public FileMetadata saveMetadata(FileMetadata metadata) {
+        save(metadata);
+        return metadata;
+    }
+    
+    public Optional<FileMetadata> findByMd5(String md5, Long tenantId) {
+        LambdaQueryWrapper<FileMetadata> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(FileMetadata::getMd5, md5)
+               .eq(FileMetadata::getTenantId, tenantId)
+               .eq(FileMetadata::getDeleted, 0);
+        return Optional.ofNullable(getOne(wrapper));
+    }
+    
+    public Optional<FileMetadata> findById(String id, Long tenantId) {
+        LambdaQueryWrapper<FileMetadata> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(FileMetadata::getId, id)
+               .eq(FileMetadata::getTenantId, tenantId)
+               .eq(FileMetadata::getDeleted, 0);
+        return Optional.ofNullable(getOne(wrapper));
+    }
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/service/metadata/FileMetadataService.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/service/metadata/FileMetadataService.java
@@ -20,16 +20,14 @@ public class FileMetadataService extends ServiceImpl<FileMetadataMapper, FileMet
     public Optional<FileMetadata> findByMd5(String md5, Long tenantId) {
         LambdaQueryWrapper<FileMetadata> wrapper = new LambdaQueryWrapper<>();
         wrapper.eq(FileMetadata::getMd5, md5)
-               .eq(FileMetadata::getTenantId, tenantId)
-               .eq(FileMetadata::getDeleted, 0);
+               .eq(FileMetadata::getTenantId, tenantId);
         return Optional.ofNullable(getOne(wrapper));
     }
     
     public Optional<FileMetadata> findById(String id, Long tenantId) {
         LambdaQueryWrapper<FileMetadata> wrapper = new LambdaQueryWrapper<>();
         wrapper.eq(FileMetadata::getId, id)
-               .eq(FileMetadata::getTenantId, tenantId)
-               .eq(FileMetadata::getDeleted, 0);
+               .eq(FileMetadata::getTenantId, tenantId);
         return Optional.ofNullable(getOne(wrapper));
     }
 }

--- a/scm-file/service/src/main/java/com/scmcloud/file/service/storage/MinioStorageEngine.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/service/storage/MinioStorageEngine.java
@@ -19,7 +19,6 @@ import java.util.UUID;
 @Component
 @RequiredArgsConstructor
 public class MinioStorageEngine implements StorageEngine {
-    
     private final MinioClient minioClient;
     private final StorageConfig config;
     

--- a/scm-file/service/src/main/java/com/scmcloud/file/service/storage/MinioStorageEngine.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/service/storage/MinioStorageEngine.java
@@ -1,0 +1,121 @@
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import com.scmcloud.file.config.StorageConfig;
+import com.scmcloud.file.entity.FileMetadata;
+import io.minio.*;
+import io.minio.http.Method;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MinioStorageEngine implements StorageEngine {
+    
+    private final MinioClient minioClient;
+    private final StorageConfig config;
+    
+    @Override
+    public FileMetadata upload(byte[] fileBytes, String fileName, String contentType, Long tenantId) {
+        try {
+            String storageKey = generateStorageKey(tenantId, fileName);
+            
+            minioClient.putObject(PutObjectArgs.builder()
+                    .bucket(config.getBucketName())
+                    .object(storageKey)
+                    .stream(new ByteArrayInputStream(fileBytes), fileBytes.length, 10485760)
+                    .contentType(contentType)
+                    .build());
+            
+            FileMetadata metadata = new FileMetadata();
+            metadata.setOriginalName(fileName);
+            metadata.setStorageKey(storageKey);
+            metadata.setContentType(contentType);
+            metadata.setFileSize((long) fileBytes.length);
+            metadata.setStorageEngine("MINIO");
+            metadata.setTenantId(tenantId);
+            
+            return metadata;
+        } catch (Exception e) {
+            log.error("Failed to upload file to MinIO", e);
+            throw new RuntimeException("File upload failed", e);
+        }
+    }
+    
+    @Override
+    public InputStream download(String fileKey) {
+        try {
+            return minioClient.getObject(GetObjectArgs.builder()
+                    .bucket(config.getBucketName())
+                    .object(fileKey)
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to download file from MinIO", e);
+            throw new RuntimeException("File download failed", e);
+        }
+    }
+    
+    @Override
+    public String generatePresignedUrl(String fileKey, Duration expiry) {
+        try {
+            return minioClient.getPresignedObjectUrl(GetPresignedObjectUrlArgs.builder()
+                    .method(Method.GET)
+                    .bucket(config.getBucketName())
+                    .object(fileKey)
+                    .expiry((int) expiry.toSeconds())
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to generate presigned URL", e);
+            throw new RuntimeException("URL generation failed", e);
+        }
+    }
+    
+    @Override
+    public void delete(String fileKey) {
+        try {
+            minioClient.removeObject(RemoveObjectArgs.builder()
+                    .bucket(config.getBucketName())
+                    .object(fileKey)
+                    .build());
+        } catch (Exception e) {
+            log.error("Failed to delete file from MinIO", e);
+            throw new RuntimeException("File deletion failed", e);
+        }
+    }
+    
+    @Override
+    public boolean exists(String fileKey) {
+        try {
+            minioClient.statObject(StatObjectArgs.builder()
+                    .bucket(config.getBucketName())
+                    .object(fileKey)
+                    .build());
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    @Override
+    public StorageType support() {
+        return StorageType.MINIO;
+    }
+    
+    private String generateStorageKey(Long tenantId, String fileName) {
+        String extension = "";
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot > 0) {
+            extension = fileName.substring(lastDot);
+        }
+        String datePath = LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy/MM/dd"));
+        return tenantId + "/" + datePath + "/" + UUID.randomUUID() + extension;
+    }
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageEngine.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageEngine.java
@@ -1,0 +1,21 @@
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import com.scmcloud.file.entity.FileMetadata;
+import java.io.InputStream;
+import java.time.Duration;
+
+public interface StorageEngine {
+    
+    FileMetadata upload(byte[] fileBytes, String fileName, String contentType, Long tenantId);
+    
+    InputStream download(String fileKey);
+    
+    String generatePresignedUrl(String fileKey, Duration expiry);
+    
+    void delete(String fileKey);
+    
+    boolean exists(String fileKey);
+    
+    StorageType support();
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageFactory.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/service/storage/StorageFactory.java
@@ -1,0 +1,42 @@
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+public class StorageFactory {
+    
+    private final List<StorageEngine> engineList;
+    private final Map<StorageType, StorageEngine> engineMap = new EnumMap<>(StorageType.class);
+    
+    public StorageFactory(List<StorageEngine> engineList) {
+        this.engineList = engineList;
+    }
+    
+    @PostConstruct
+    public void init() {
+        for (StorageEngine engine : engineList) {
+            StorageType type = engine.support();
+            engineMap.put(type, engine);
+            log.info("Registered storage engine: {} -> {}", type, engine.getClass().getSimpleName());
+        }
+    }
+    
+    public StorageEngine getEngine(StorageType type) {
+        StorageEngine engine = engineMap.get(type);
+        if (engine == null) {
+            throw new IllegalArgumentException("No storage engine found for type: " + type);
+        }
+        return engine;
+    }
+    
+    public StorageEngine getDefaultEngine() {
+        return getEngine(StorageType.MINIO);
+    }
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/service/upload/InstantUploadService.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/service/upload/InstantUploadService.java
@@ -1,0 +1,20 @@
+package com.scmcloud.file.service.upload;
+
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.service.metadata.FileMetadataService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class InstantUploadService {
+    
+    private final FileMetadataService metadataService;
+    
+    public Optional<FileMetadata> checkExist(String md5, Long tenantId) {
+        return metadataService.findByMd5(md5, tenantId);
+    }
+}

--- a/scm-file/service/src/main/java/com/scmcloud/file/service/upload/UploadService.java
+++ b/scm-file/service/src/main/java/com/scmcloud/file/service/upload/UploadService.java
@@ -1,0 +1,60 @@
+package com.scmcloud.file.service.upload;
+
+import com.scmcloud.file.api.enums.UploadTaskStatus;
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.entity.UploadTask;
+import com.scmcloud.file.mapper.UploadTaskMapper;
+import com.scmcloud.file.service.metadata.FileMetadataService;
+import com.scmcloud.file.service.storage.StorageEngine;
+import com.scmcloud.file.service.storage.StorageFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UploadService {
+    
+    private final StorageFactory storageFactory;
+    private final FileMetadataService metadataService;
+    private final InstantUploadService instantUploadService;
+    private final UploadTaskMapper uploadTaskMapper;
+    
+    @Transactional
+    public FileMetadata upload(byte[] fileBytes, String fileName, String contentType,
+                               String bizType, String bizId, Long tenantId) {
+        String md5 = DigestUtils.md5Hex(fileBytes);
+        
+        return instantUploadService.checkExist(md5, tenantId)
+                .orElseGet(() -> doUpload(fileBytes, fileName, contentType, md5, bizType, bizId, tenantId));
+    }
+    
+    private FileMetadata doUpload(byte[] fileBytes, String fileName, String contentType,
+                                   String md5, String bizType, String bizId, Long tenantId) {
+        StorageEngine engine = storageFactory.getDefaultEngine();
+        FileMetadata metadata = engine.upload(fileBytes, fileName, contentType, tenantId);
+        metadata.setMd5(md5);
+        metadata.setFileSize((long) fileBytes.length);
+        metadata.setVersion(1);
+        metadata.setBizType(bizType);
+        metadata.setBizId(bizId);
+        metadata.setCreateBy(tenantId);
+        metadataService.saveMetadata(metadata);
+        return metadata;
+    }
+    
+    public String initMultipartUpload(String fileName, Long fileSize, Long tenantId) {
+        UploadTask task = new UploadTask();
+        task.setId(UUID.randomUUID().toString());
+        task.setFileName(fileName);
+        task.setFileSize(fileSize);
+        task.setStatus(UploadTaskStatus.INIT);
+        task.setTenantId(tenantId);
+        uploadTaskMapper.insert(task);
+        return task.getId();
+    }
+}

--- a/scm-file/service/src/main/resources/application.yml
+++ b/scm-file/service/src/main/resources/application.yml
@@ -1,0 +1,30 @@
+server:
+  port: 8201
+
+spring:
+  application:
+    name: scm-file
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/db_system
+    username: ${DB_USERNAME:admin}
+    password: ${DB_PASSWORD:admin123}
+  servlet:
+    multipart:
+      max-file-size: 100MB
+      max-request-size: 100MB
+
+storage:
+  minio:
+    endpoint: ${MINIO_ENDPOINT:http://localhost:9000}
+    access-key: ${MINIO_ACCESS_KEY:minioadmin}
+    secret-key: ${MINIO_SECRET_KEY:minioadmin}
+    bucket-name: ${MINIO_BUCKET:scm-files}
+
+mybatis-plus:
+  mapper-locations: classpath*:mapper/**/*.xml
+  configuration:
+    map-underscore-to-camel-case: true
+
+logging:
+  level:
+    com.scmcloud.file: DEBUG

--- a/scm-file/service/src/main/resources/db/migration/V1_0_0__create_file_tables.sql
+++ b/scm-file/service/src/main/resources/db/migration/V1_0_0__create_file_tables.sql
@@ -1,0 +1,62 @@
+-- File metadata table
+CREATE TABLE sys_file_metadata (
+    id              VARCHAR(36) PRIMARY KEY,
+    original_name   VARCHAR(255) NOT NULL,
+    storage_key     VARCHAR(500) NOT NULL,
+    content_type    VARCHAR(100),
+    file_size       BIGINT,
+    storage_engine  VARCHAR(50) NOT NULL,
+    md5             VARCHAR(32),
+    version         INTEGER DEFAULT 1,
+    biz_type        VARCHAR(50),
+    biz_id          VARCHAR(100),
+    status          VARCHAR(20) DEFAULT 'NORMAL',
+    ref_count       INTEGER DEFAULT 1,
+    tenant_id       BIGINT NOT NULL,
+    create_by       BIGINT,
+    update_by       BIGINT,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    update_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted         INTEGER DEFAULT 0
+);
+
+CREATE INDEX idx_file_metadata_md5 ON sys_file_metadata(md5);
+CREATE INDEX idx_file_metadata_tenant ON sys_file_metadata(tenant_id);
+CREATE INDEX idx_file_metadata_biz ON sys_file_metadata(biz_type, biz_id);
+
+-- File version table
+CREATE TABLE sys_file_version (
+    id              VARCHAR(36) PRIMARY KEY,
+    file_id         VARCHAR(36) NOT NULL,
+    version         INTEGER NOT NULL,
+    storage_key     VARCHAR(500) NOT NULL,
+    file_size       BIGINT,
+    md5             VARCHAR(32),
+    create_by       BIGINT,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    tenant_id       BIGINT NOT NULL
+);
+
+CREATE INDEX idx_file_version_file_id ON sys_file_version(file_id);
+
+-- Upload task table
+CREATE TABLE sys_upload_task (
+    id              VARCHAR(36) PRIMARY KEY,
+    file_name       VARCHAR(255) NOT NULL,
+    file_size       BIGINT NOT NULL,
+    md5             VARCHAR(32),
+    storage_key     VARCHAR(500),
+    total_parts     INTEGER,
+    completed_parts INTEGER DEFAULT 0,
+    status          SMALLINT NOT NULL DEFAULT 0,
+    upload_id       VARCHAR(100),
+    tenant_id       BIGINT NOT NULL,
+    create_by       BIGINT,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    update_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    deleted         INTEGER DEFAULT 0,
+    lock_version    INTEGER DEFAULT 0
+);
+
+CREATE INDEX idx_upload_task_status ON sys_upload_task(status);
+CREATE INDEX idx_upload_task_md5 ON sys_upload_task(md5);

--- a/scm-file/service/src/test/java/com/scmcloud/file/integration/FileUploadIntegrationTest.java
+++ b/scm-file/service/src/test/java/com/scmcloud/file/integration/FileUploadIntegrationTest.java
@@ -1,0 +1,51 @@
+package com.scmcloud.file.integration;
+
+import com.scmcloud.file.ScmFileApplication;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = ScmFileApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class FileUploadIntegrationTest {
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Test
+    void shouldUploadFile() {
+        MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+        body.add("file", new ByteArrayResource("test content".getBytes()) {
+            @Override
+            public String getFilename() {
+                return "test.txt";
+            }
+        });
+        body.add("bizType", "product");
+        body.add("bizId", "123");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+
+        HttpEntity<MultiValueMap<String, Object>> request = new HttpEntity<>(body, headers);
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "/api/v1/files/upload", request, String.class);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertNotNull(response.getBody());
+    }
+
+    @Test
+    void shouldCheckFileExistByMd5() {
+        ResponseEntity<String> response = restTemplate.getForEntity(
+                "/api/v1/files/check/{md5}", String.class, "nonexistent");
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+}

--- a/scm-file/service/src/test/java/com/scmcloud/file/service/metadata/FileMetadataServiceTest.java
+++ b/scm-file/service/src/test/java/com/scmcloud/file/service/metadata/FileMetadataServiceTest.java
@@ -1,0 +1,62 @@
+package com.scmcloud.file.service.metadata;
+
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.mapper.FileMetadataMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FileMetadataServiceTest {
+    
+    @Mock
+    private FileMetadataMapper mapper;
+    
+    private FileMetadataService service;
+    
+    @BeforeEach
+    void setUp() {
+        service = new FileMetadataService();
+        ReflectionTestUtils.setField(service, "baseMapper", mapper);
+    }
+    
+    @Test
+    void shouldSaveFileMetadata() {
+        // Given
+        FileMetadata metadata = new FileMetadata();
+        metadata.setId("test-id");
+        metadata.setOriginalName("test.txt");
+        when(mapper.insert(any(FileMetadata.class))).thenReturn(1);
+        
+        // When
+        FileMetadata result = service.saveMetadata(metadata);
+        
+        // Then
+        assertNotNull(result);
+        verify(mapper).insert(metadata);
+    }
+    
+    @Test
+    void shouldFindByMd5() {
+        // Given
+        String md5 = "abc123";
+        FileMetadata metadata = new FileMetadata();
+        metadata.setMd5(md5);
+        when(mapper.selectOne(any(LambdaQueryWrapper.class), any(Boolean.class))).thenReturn(metadata);
+        
+        // When
+        Optional<FileMetadata> result = service.findByMd5(md5, 1L);
+        
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals(md5, result.get().getMd5());
+    }
+}

--- a/scm-file/service/src/test/java/com/scmcloud/file/service/storage/MinioStorageEngineTest.java
+++ b/scm-file/service/src/test/java/com/scmcloud/file/service/storage/MinioStorageEngineTest.java
@@ -1,0 +1,61 @@
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.config.StorageConfig;
+import com.scmcloud.file.entity.FileMetadata;
+import io.minio.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MinioStorageEngineTest {
+    
+    @Mock
+    private MinioClient minioClient;
+    
+    @Mock
+    private StorageConfig config;
+    
+    @InjectMocks
+    private MinioStorageEngine engine;
+    
+    @BeforeEach
+    void setUp() {
+        when(config.getBucketName()).thenReturn("test-bucket");
+    }
+    
+    @Test
+    void shouldUploadFile() throws Exception {
+        // Given
+        byte[] fileBytes = "test content".getBytes();
+        when(minioClient.putObject(any(PutObjectArgs.class))).thenReturn(null);
+        
+        // When
+        FileMetadata result = engine.upload(fileBytes, "test.txt", "text/plain", 1L);
+        
+        // Then
+        assertNotNull(result);
+        assertEquals("test.txt", result.getOriginalName());
+        assertEquals("text/plain", result.getContentType());
+        assertEquals(12L, result.getFileSize());
+        verify(minioClient).putObject(any(PutObjectArgs.class));
+    }
+    
+    @Test
+    void shouldCheckFileExists() throws Exception {
+        // Given
+        when(minioClient.statObject(any(StatObjectArgs.class))).thenReturn(null);
+        
+        // When
+        boolean exists = engine.exists("test-key");
+        
+        // Then
+        assertTrue(exists);
+    }
+}

--- a/scm-file/service/src/test/java/com/scmcloud/file/service/storage/StorageFactoryTest.java
+++ b/scm-file/service/src/test/java/com/scmcloud/file/service/storage/StorageFactoryTest.java
@@ -1,0 +1,39 @@
+package com.scmcloud.file.service.storage;
+
+import com.scmcloud.file.api.enums.StorageType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class StorageFactoryTest {
+    
+    @Test
+    void shouldGetEngineByType() {
+        // Given
+        StorageEngine minioEngine = mock(StorageEngine.class);
+        when(minioEngine.support()).thenReturn(StorageType.MINIO);
+        
+        StorageFactory factory = new StorageFactory(List.of(minioEngine));
+        factory.init();
+        
+        // When
+        StorageEngine result = factory.getEngine(StorageType.MINIO);
+        
+        // Then
+        assertEquals(minioEngine, result);
+    }
+    
+    @Test
+    void shouldThrowExceptionForUnsupportedType() {
+        // Given
+        StorageFactory factory = new StorageFactory(List.of());
+        factory.init();
+        
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> factory.getEngine(StorageType.MINIO));
+    }
+}

--- a/scm-file/service/src/test/java/com/scmcloud/file/service/upload/InstantUploadServiceTest.java
+++ b/scm-file/service/src/test/java/com/scmcloud/file/service/upload/InstantUploadServiceTest.java
@@ -1,0 +1,54 @@
+package com.scmcloud.file.service.upload;
+
+import com.scmcloud.file.entity.FileMetadata;
+import com.scmcloud.file.service.metadata.FileMetadataService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.Optional;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class InstantUploadServiceTest {
+    
+    @Mock
+    private FileMetadataService metadataService;
+    
+    @InjectMocks
+    private InstantUploadService service;
+    
+    @Test
+    void shouldReturnExistingFileWhenMd5Matches() {
+        // Given
+        String md5 = "abc123";
+        Long tenantId = 1L;
+        FileMetadata existing = new FileMetadata();
+        existing.setId("existing-id");
+        existing.setMd5(md5);
+        when(metadataService.findByMd5(md5, tenantId)).thenReturn(Optional.of(existing));
+        
+        // When
+        Optional<FileMetadata> result = service.checkExist(md5, tenantId);
+        
+        // Then
+        assertTrue(result.isPresent());
+        assertEquals("existing-id", result.get().getId());
+    }
+    
+    @Test
+    void shouldReturnEmptyWhenMd5NotExists() {
+        // Given
+        String md5 = "not-exists";
+        Long tenantId = 1L;
+        when(metadataService.findByMd5(md5, tenantId)).thenReturn(Optional.empty());
+        
+        // When
+        Optional<FileMetadata> result = service.checkExist(md5, tenantId);
+        
+        // Then
+        assertFalse(result.isPresent());
+    }
+}

--- a/scm-message/api/pom.xml
+++ b/scm-message/api/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-message</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scm-message-api</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/scm-message/api/src/main/java/com/scmcloud/message/api/EventPublisherApi.java
+++ b/scm-message/api/src/main/java/com/scmcloud/message/api/EventPublisherApi.java
@@ -1,0 +1,16 @@
+package com.scmcloud.message.api;
+
+import com.scmcloud.message.api.dto.DomainEventDTO;
+
+public interface EventPublisherApi {
+
+    /**
+     * Publish event to outbox (transactional)
+     */
+    void publish(DomainEventDTO event);
+
+    /**
+     * Publish event directly to Kafka (non-transactional)
+     */
+    void publishDirect(DomainEventDTO event);
+}

--- a/scm-message/api/src/main/java/com/scmcloud/message/api/dto/DomainEventDTO.java
+++ b/scm-message/api/src/main/java/com/scmcloud/message/api/dto/DomainEventDTO.java
@@ -1,0 +1,17 @@
+package com.scmcloud.message.api.dto;
+
+import lombok.Data;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Map;
+
+@Data
+public class DomainEventDTO implements Serializable {
+    private String eventId;
+    private String eventType;
+    private String aggregateType;
+    private String aggregateId;
+    private Long tenantId;
+    private Date timestamp;
+    private Map<String, Object> payload;
+}

--- a/scm-message/api/src/main/java/com/scmcloud/message/api/enums/OutboxStatus.java
+++ b/scm-message/api/src/main/java/com/scmcloud/message/api/enums/OutboxStatus.java
@@ -1,0 +1,8 @@
+package com.scmcloud.message.api.enums;
+
+public enum OutboxStatus {
+    PENDING,
+    PUBLISHED,
+    FAILED,
+    RETRYING
+}

--- a/scm-message/pom.xml
+++ b/scm-message/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-platform</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../com.scm.parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>scm-message</artifactId>
+    <packaging>pom</packaging>
+
+    <name>SCM Message Service</name>
+    <description>Unified event bus service</description>
+
+    <modules>
+        <module>api</module>
+        <module>service</module>
+    </modules>
+</project>

--- a/scm-message/service/pom.xml
+++ b/scm-message/service/pom.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-message</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>scm-message-service</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-message-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.scmcloud</groupId>
+            <artifactId>scm-common-data</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/scm-message/service/src/main/java/com/scmcloud/message/ScmMessageApplication.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/ScmMessageApplication.java
@@ -1,0 +1,14 @@
+package com.scmcloud.message;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@SpringBootApplication
+@EnableScheduling
+public class ScmMessageApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ScmMessageApplication.class, args);
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/config/KafkaConfig.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/config/KafkaConfig.java
@@ -1,0 +1,35 @@
+package com.scmcloud.message.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+    
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServers;
+    
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.ACKS_CONFIG, "all");
+        config.put(ProducerConfig.RETRIES_CONFIG, 3);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+    
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/entity/EventOutbox.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/entity/EventOutbox.java
@@ -1,0 +1,24 @@
+package com.scmcloud.message.entity;
+
+import com.baomidou.mybatisplus.annotation.*;
+import lombok.Data;
+import java.util.Date;
+
+@Data
+@TableName("sys_event_outbox")
+public class EventOutbox {
+    @TableId(type = IdType.ASSIGN_UUID)
+    private String id;
+    private String eventType;
+    private String aggregateType;
+    private String aggregateId;
+    private String payload;
+    private Integer retryCount;
+    private Integer maxRetries;
+    private String status;
+    private String errorMessage;
+    private Long tenantId;
+    private Date createTime;
+    private Date publishedAt;
+    private Date nextRetryAt;
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/event/DomainEvent.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/event/DomainEvent.java
@@ -1,0 +1,19 @@
+package com.scmcloud.message.event;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+public interface DomainEvent {
+    String getEventId();
+    String getEventType();
+    String getAggregateType();
+    String getAggregateId();
+    Long getTenantId();
+    Date getTimestamp();
+    Map<String, Object> getPayload();
+    
+    default String generateEventId() {
+        return UUID.randomUUID().toString();
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/event/InventoryChangedEvent.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/event/InventoryChangedEvent.java
@@ -1,7 +1,9 @@
 package com.scmcloud.message.event;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,6 +11,8 @@ import java.util.UUID;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class InventoryChangedEvent implements DomainEvent {
     private String eventId;
     private String skuId;

--- a/scm-message/service/src/main/java/com/scmcloud/message/event/InventoryChangedEvent.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/event/InventoryChangedEvent.java
@@ -1,0 +1,62 @@
+package com.scmcloud.message.event;
+
+import lombok.Builder;
+import lombok.Data;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+public class InventoryChangedEvent implements DomainEvent {
+    private String eventId;
+    private String skuId;
+    private String warehouseId;
+    private Integer quantityChange;
+    private Integer newQuantity;
+    private String changeType;
+    private Long tenantId;
+    private Date timestamp;
+    
+    @Override
+    public String getEventType() {
+        return "INVENTORY_CHANGED";
+    }
+    
+    @Override
+    public String getAggregateType() {
+        return "Inventory";
+    }
+    
+    @Override
+    public String getAggregateId() {
+        return skuId + ":" + warehouseId;
+    }
+    
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("skuId", skuId);
+        payload.put("warehouseId", warehouseId);
+        payload.put("quantityChange", quantityChange);
+        payload.put("newQuantity", newQuantity);
+        payload.put("changeType", changeType);
+        return payload;
+    }
+    
+    public static InventoryChangedEvent of(String skuId, String warehouseId, 
+                                            Integer quantityChange, Integer newQuantity,
+                                            String changeType, Long tenantId) {
+        return InventoryChangedEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .skuId(skuId)
+                .warehouseId(warehouseId)
+                .quantityChange(quantityChange)
+                .newQuantity(newQuantity)
+                .changeType(changeType)
+                .tenantId(tenantId)
+                .timestamp(new Date())
+                .build();
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/event/OrderCreatedEvent.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/event/OrderCreatedEvent.java
@@ -1,0 +1,51 @@
+package com.scmcloud.message.event;
+
+import lombok.Builder;
+import lombok.Data;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+public class OrderCreatedEvent implements DomainEvent {
+    private String eventId;
+    private String orderId;
+    private String orderNo;
+    private Long tenantId;
+    private Date timestamp;
+    
+    @Override
+    public String getEventType() {
+        return "ORDER_CREATED";
+    }
+    
+    @Override
+    public String getAggregateType() {
+        return "Order";
+    }
+    
+    @Override
+    public String getAggregateId() {
+        return orderId;
+    }
+    
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("orderId", orderId);
+        payload.put("orderNo", orderNo);
+        return payload;
+    }
+    
+    public static OrderCreatedEvent of(String orderId, String orderNo, Long tenantId) {
+        return OrderCreatedEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .orderId(orderId)
+                .orderNo(orderNo)
+                .tenantId(tenantId)
+                .timestamp(new Date())
+                .build();
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/event/OrderCreatedEvent.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/event/OrderCreatedEvent.java
@@ -1,7 +1,9 @@
 package com.scmcloud.message.event;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,6 +11,8 @@ import java.util.UUID;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class OrderCreatedEvent implements DomainEvent {
     private String eventId;
     private String orderId;

--- a/scm-message/service/src/main/java/com/scmcloud/message/event/PriceChangedEvent.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/event/PriceChangedEvent.java
@@ -1,7 +1,9 @@
 package com.scmcloud.message.event;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.HashMap;
@@ -10,6 +12,8 @@ import java.util.UUID;
 
 @Data
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PriceChangedEvent implements DomainEvent {
     private String eventId;
     private String productId;

--- a/scm-message/service/src/main/java/com/scmcloud/message/event/PriceChangedEvent.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/event/PriceChangedEvent.java
@@ -1,0 +1,63 @@
+package com.scmcloud.message.event;
+
+import lombok.Builder;
+import lombok.Data;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Data
+@Builder
+public class PriceChangedEvent implements DomainEvent {
+    private String eventId;
+    private String productId;
+    private String skuId;
+    private BigDecimal oldPrice;
+    private BigDecimal newPrice;
+    private String priceListId;
+    private Long tenantId;
+    private Date timestamp;
+    
+    @Override
+    public String getEventType() {
+        return "PRICE_CHANGED";
+    }
+    
+    @Override
+    public String getAggregateType() {
+        return "Price";
+    }
+    
+    @Override
+    public String getAggregateId() {
+        return productId + ":" + skuId;
+    }
+    
+    @Override
+    public Map<String, Object> getPayload() {
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("productId", productId);
+        payload.put("skuId", skuId);
+        payload.put("oldPrice", oldPrice);
+        payload.put("newPrice", newPrice);
+        payload.put("priceListId", priceListId);
+        return payload;
+    }
+    
+    public static PriceChangedEvent of(String productId, String skuId, 
+                                        BigDecimal oldPrice, BigDecimal newPrice,
+                                        String priceListId, Long tenantId) {
+        return PriceChangedEvent.builder()
+                .eventId(UUID.randomUUID().toString())
+                .productId(productId)
+                .skuId(skuId)
+                .oldPrice(oldPrice)
+                .newPrice(newPrice)
+                .priceListId(priceListId)
+                .tenantId(tenantId)
+                .timestamp(new Date())
+                .build();
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/mapper/EventOutboxMapper.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/mapper/EventOutboxMapper.java
@@ -1,0 +1,19 @@
+package com.scmcloud.message.mapper;
+
+import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import com.scmcloud.message.entity.EventOutbox;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
+import java.util.Date;
+import java.util.List;
+
+@Mapper
+public interface EventOutboxMapper extends BaseMapper<EventOutbox> {
+    
+    @Select("SELECT * FROM sys_event_outbox WHERE status = 'PENDING' AND next_retry_at <= #{now} LIMIT #{limit}")
+    List<EventOutbox> findPendingEvents(@Param("now") Date now, @Param("limit") int limit);
+    
+    @Select("SELECT * FROM sys_event_outbox WHERE status = 'RETRYING' AND next_retry_at <= #{now} LIMIT #{limit}")
+    List<EventOutbox> findRetryingEvents(@Param("now") Date now, @Param("limit") int limit);
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/producer/KafkaEventProducer.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/producer/KafkaEventProducer.java
@@ -1,0 +1,48 @@
+package com.scmcloud.message.producer;
+
+import com.scmcloud.message.event.DomainEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Component;
+import java.util.concurrent.CompletableFuture;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaEventProducer {
+    
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+    
+    private static final String TOPIC_PREFIX = "scm.";
+    
+    public CompletableFuture<SendResult<String, String>> send(DomainEvent event) {
+        String topic = TOPIC_PREFIX + event.getAggregateType().toLowerCase() + ".events";
+        String key = event.getAggregateId();
+        
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            
+            CompletableFuture<SendResult<String, String>> future = 
+                    kafkaTemplate.send(topic, key, payload);
+            
+            future.whenComplete((result, ex) -> {
+                if (ex == null) {
+                    log.info("Event sent successfully: topic={}, key={}, eventType={}", 
+                            topic, key, event.getEventType());
+                } else {
+                    log.error("Failed to send event: topic={}, key={}, eventType={}", 
+                            topic, key, event.getEventType(), ex);
+                }
+            });
+            
+            return future;
+        } catch (Exception e) {
+            log.error("Failed to serialize event", e);
+            throw new RuntimeException("Failed to serialize event", e);
+        }
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxPublisher.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxPublisher.java
@@ -1,0 +1,77 @@
+package com.scmcloud.message.producer;
+
+import com.scmcloud.message.entity.EventOutbox;
+import com.scmcloud.message.event.DomainEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OutboxPublisher {
+
+    private final OutboxService outboxService;
+    private final KafkaEventProducer kafkaEventProducer;
+
+    @Scheduled(fixedDelay = 5000)
+    public void publishPendingEvents() {
+        List<EventOutbox> pendingEvents = outboxService.findPendingEvents(100);
+
+        for (EventOutbox event : pendingEvents) {
+            publishEvent(event);
+        }
+    }
+
+    @Scheduled(fixedDelay = 30000)
+    public void publishRetryingEvents() {
+        List<EventOutbox> retryingEvents = outboxService.findRetryingEvents(50);
+
+        for (EventOutbox event : retryingEvents) {
+            publishEvent(event);
+        }
+    }
+
+    private void publishEvent(EventOutbox event) {
+        try {
+            DomainEvent domainEvent = convertToDomainEvent(event);
+
+            kafkaEventProducer.send(domainEvent)
+                    .whenComplete((result, ex) -> {
+                        if (ex == null) {
+                            outboxService.markAsPublished(event.getId());
+                        } else {
+                            outboxService.markAsFailed(event.getId(), ex.getMessage());
+                        }
+                    });
+        } catch (Exception e) {
+            log.error("Failed to publish event: {}", event.getId(), e);
+            outboxService.markAsFailed(event.getId(), e.getMessage());
+        }
+    }
+
+    private DomainEvent convertToDomainEvent(EventOutbox outbox) {
+        return new DomainEvent() {
+            @Override
+            public String getEventId() { return outbox.getId(); }
+            @Override
+            public String getEventType() { return outbox.getEventType(); }
+            @Override
+            public String getAggregateType() { return outbox.getAggregateType(); }
+            @Override
+            public String getAggregateId() { return outbox.getAggregateId(); }
+            @Override
+            public Long getTenantId() { return outbox.getTenantId(); }
+            @Override
+            public Date getTimestamp() { return outbox.getCreateTime(); }
+            @Override
+            public Map<String, Object> getPayload() { return Collections.emptyMap(); }
+        };
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxPublisher.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxPublisher.java
@@ -1,5 +1,7 @@
 package com.scmcloud.message.producer;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.scmcloud.message.entity.EventOutbox;
 import com.scmcloud.message.event.DomainEvent;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,7 @@ public class OutboxPublisher {
 
     private final OutboxService outboxService;
     private final KafkaEventProducer kafkaEventProducer;
+    private final ObjectMapper objectMapper;
 
     @Scheduled(fixedDelay = 5000)
     public void publishPendingEvents() {
@@ -57,6 +60,15 @@ public class OutboxPublisher {
     }
 
     private DomainEvent convertToDomainEvent(EventOutbox outbox) {
+        Map<String, Object> payloadMap;
+        try {
+            payloadMap = objectMapper.readValue(outbox.getPayload(), new TypeReference<>() {});
+        } catch (Exception e) {
+            log.warn("Failed to deserialize payload for event: {}, using empty map", outbox.getId());
+            payloadMap = Collections.emptyMap();
+        }
+
+        final Map<String, Object> payload = payloadMap;
         return new DomainEvent() {
             @Override
             public String getEventId() { return outbox.getId(); }
@@ -71,7 +83,7 @@ public class OutboxPublisher {
             @Override
             public Date getTimestamp() { return outbox.getCreateTime(); }
             @Override
-            public Map<String, Object> getPayload() { return Collections.emptyMap(); }
+            public Map<String, Object> getPayload() { return payload; }
         };
     }
 }

--- a/scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxService.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxService.java
@@ -1,0 +1,82 @@
+package com.scmcloud.message.producer;
+
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.scmcloud.message.entity.EventOutbox;
+import com.scmcloud.message.event.DomainEvent;
+import com.scmcloud.message.mapper.EventOutboxMapper;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import java.util.Date;
+import java.util.List;
+
+@Slf4j
+@Service
+public class OutboxService extends ServiceImpl<EventOutboxMapper, EventOutbox> {
+    
+    private final ObjectMapper objectMapper;
+    
+    public OutboxService(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+    
+    public EventOutbox save(DomainEvent event) {
+        try {
+            EventOutbox outbox = new EventOutbox();
+            outbox.setId(event.getEventId());
+            outbox.setEventType(event.getEventType());
+            outbox.setAggregateType(event.getAggregateType());
+            outbox.setAggregateId(event.getAggregateId());
+            outbox.setPayload(objectMapper.writeValueAsString(event.getPayload()));
+            outbox.setRetryCount(0);
+            outbox.setMaxRetries(3);
+            outbox.setStatus("PENDING");
+            outbox.setTenantId(event.getTenantId());
+            outbox.setCreateTime(new Date());
+            outbox.setNextRetryAt(new Date());
+            
+            save(outbox);
+            return outbox;
+        } catch (Exception e) {
+            log.error("Failed to save event to outbox", e);
+            throw new RuntimeException("Failed to save event", e);
+        }
+    }
+    
+    public void markAsPublished(String eventId) {
+        EventOutbox outbox = getById(eventId);
+        if (outbox != null) {
+            outbox.setStatus("PUBLISHED");
+            outbox.setPublishedAt(new Date());
+            updateById(outbox);
+        }
+    }
+    
+    public void markAsFailed(String eventId, String errorMessage) {
+        EventOutbox outbox = getById(eventId);
+        if (outbox != null) {
+            outbox.setRetryCount(outbox.getRetryCount() + 1);
+            outbox.setErrorMessage(errorMessage);
+            
+            if (outbox.getRetryCount() >= outbox.getMaxRetries()) {
+                outbox.setStatus("FAILED");
+            } else {
+                outbox.setStatus("RETRYING");
+                // Exponential backoff: 1min, 5min, 15min
+                long[] backoff = {60000, 300000, 900000};
+                long delay = backoff[Math.min(outbox.getRetryCount(), backoff.length - 1)];
+                outbox.setNextRetryAt(new Date(System.currentTimeMillis() + delay));
+            }
+            
+            updateById(outbox);
+        }
+    }
+    
+    public List<EventOutbox> findPendingEvents(int limit) {
+        return baseMapper.findPendingEvents(new Date(), limit);
+    }
+    
+    public List<EventOutbox> findRetryingEvents(int limit) {
+        return baseMapper.findRetryingEvents(new Date(), limit);
+    }
+}

--- a/scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxService.java
+++ b/scm-message/service/src/main/java/com/scmcloud/message/producer/OutboxService.java
@@ -20,7 +20,7 @@ public class OutboxService extends ServiceImpl<EventOutboxMapper, EventOutbox> {
         this.objectMapper = objectMapper;
     }
     
-    public EventOutbox save(DomainEvent event) {
+    public EventOutbox saveEvent(DomainEvent event) {
         try {
             EventOutbox outbox = new EventOutbox();
             outbox.setId(event.getEventId());

--- a/scm-message/service/src/main/resources/application.yml
+++ b/scm-message/service/src/main/resources/application.yml
@@ -1,0 +1,21 @@
+server:
+  port: 8209
+
+spring:
+  application:
+    name: scm-message
+  datasource:
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/db_system
+    username: ${DB_USERNAME:admin}
+    password: ${DB_PASSWORD:admin123}
+  kafka:
+    bootstrap-servers: ${KAFKA_SERVERS:localhost:9092}
+
+mybatis-plus:
+  mapper-locations: classpath*:mapper/**/*.xml
+  configuration:
+    map-underscore-to-camel-case: true
+
+logging:
+  level:
+    com.scmcloud.message: DEBUG

--- a/scm-message/service/src/main/resources/db/migration/V1_0_0__create_message_tables.sql
+++ b/scm-message/service/src/main/resources/db/migration/V1_0_0__create_message_tables.sql
@@ -1,0 +1,40 @@
+-- Event outbox table for transactional event publishing
+CREATE TABLE sys_event_outbox (
+    id              VARCHAR(36) PRIMARY KEY,
+    event_type      VARCHAR(100) NOT NULL,
+    aggregate_type  VARCHAR(100) NOT NULL,
+    aggregate_id    VARCHAR(36) NOT NULL,
+    payload         TEXT NOT NULL,
+    retry_count     INTEGER DEFAULT 0,
+    max_retries     INTEGER DEFAULT 3,
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    error_message   TEXT,
+    tenant_id       BIGINT NOT NULL,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    published_at    TIMESTAMP,
+    next_retry_at   TIMESTAMP
+);
+
+CREATE INDEX idx_outbox_status ON sys_event_outbox(status);
+CREATE INDEX idx_outbox_next_retry ON sys_event_outbox(next_retry_at);
+CREATE INDEX idx_outbox_aggregate ON sys_event_outbox(aggregate_type, aggregate_id);
+
+-- Dead letter queue table
+CREATE TABLE sys_event_dlq (
+    id              VARCHAR(36) PRIMARY KEY,
+    original_event_id VARCHAR(36) NOT NULL,
+    event_type      VARCHAR(100) NOT NULL,
+    aggregate_type  VARCHAR(100) NOT NULL,
+    aggregate_id    VARCHAR(36) NOT NULL,
+    payload         TEXT NOT NULL,
+    error_message   TEXT,
+    error_stack     TEXT,
+    retry_count     INTEGER DEFAULT 0,
+    tenant_id       BIGINT NOT NULL,
+    create_time     TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    resolved        BOOLEAN DEFAULT FALSE,
+    resolved_at     TIMESTAMP
+);
+
+CREATE INDEX idx_dlq_event_type ON sys_event_dlq(event_type);
+CREATE INDEX idx_dlq_resolved ON sys_event_dlq(resolved);

--- a/scm-message/service/src/test/java/com/scmcloud/message/integration/MessageIntegrationTest.java
+++ b/scm-message/service/src/test/java/com/scmcloud/message/integration/MessageIntegrationTest.java
@@ -21,7 +21,7 @@ class MessageIntegrationTest {
         DomainEvent event = OrderCreatedEvent.of("order-1", "ORD001", 1L);
         
         // When
-        var result = outboxService.save(event);
+        var result = outboxService.saveEvent(event);
         
         // Then
         assertNotNull(result);

--- a/scm-message/service/src/test/java/com/scmcloud/message/integration/MessageIntegrationTest.java
+++ b/scm-message/service/src/test/java/com/scmcloud/message/integration/MessageIntegrationTest.java
@@ -1,0 +1,31 @@
+package com.scmcloud.message.integration;
+
+import com.scmcloud.message.ScmMessageApplication;
+import com.scmcloud.message.event.DomainEvent;
+import com.scmcloud.message.event.OrderCreatedEvent;
+import com.scmcloud.message.producer.OutboxService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = ScmMessageApplication.class)
+class MessageIntegrationTest {
+    
+    @Autowired
+    private OutboxService outboxService;
+    
+    @Test
+    void shouldSaveEventToOutbox() {
+        // Given
+        DomainEvent event = OrderCreatedEvent.of("order-1", "ORD001", 1L);
+        
+        // When
+        var result = outboxService.save(event);
+        
+        // Then
+        assertNotNull(result);
+        assertEquals("ORDER_CREATED", result.getEventType());
+        assertEquals("PENDING", result.getStatus());
+    }
+}

--- a/scm-message/service/src/test/java/com/scmcloud/message/producer/OutboxServiceTest.java
+++ b/scm-message/service/src/test/java/com/scmcloud/message/producer/OutboxServiceTest.java
@@ -1,0 +1,64 @@
+package com.scmcloud.message.producer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.scmcloud.message.entity.EventOutbox;
+import com.scmcloud.message.event.DomainEvent;
+import com.scmcloud.message.event.OrderCreatedEvent;
+import com.scmcloud.message.mapper.EventOutboxMapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxServiceTest {
+    
+    @Mock
+    private EventOutboxMapper mapper;
+    
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+    
+    @InjectMocks
+    private OutboxService outboxService;
+    
+    @Test
+    void shouldSaveEventToOutbox() {
+        // Given
+        DomainEvent event = OrderCreatedEvent.of("order-1", "ORD001", 1L);
+        when(mapper.insert(any())).thenReturn(1);
+        
+        // When
+        EventOutbox result = outboxService.save(event);
+        
+        // Then
+        assertNotNull(result);
+        assertEquals("ORDER_CREATED", result.getEventType());
+        assertEquals("PENDING", result.getStatus());
+        verify(mapper).insert(any());
+    }
+    
+    @Test
+    void shouldMarkAsPublished() {
+        // Given
+        String eventId = "event-1";
+        EventOutbox outbox = new EventOutbox();
+        outbox.setId(eventId);
+        outbox.setStatus("PENDING");
+        when(mapper.selectById(eventId)).thenReturn(outbox);
+        when(mapper.updateById(any())).thenReturn(1);
+        
+        // When
+        outboxService.markAsPublished(eventId);
+        
+        // Then
+        assertEquals("PUBLISHED", outbox.getStatus());
+        assertNotNull(outbox.getPublishedAt());
+        verify(mapper).updateById(outbox);
+    }
+}

--- a/scm-message/service/src/test/java/com/scmcloud/message/producer/OutboxServiceTest.java
+++ b/scm-message/service/src/test/java/com/scmcloud/message/producer/OutboxServiceTest.java
@@ -34,7 +34,7 @@ class OutboxServiceTest {
         when(mapper.insert(any())).thenReturn(1);
         
         // When
-        EventOutbox result = outboxService.save(event);
+        EventOutbox result = outboxService.saveEvent(event);
         
         // Then
         assertNotNull(result);


### PR DESCRIPTION
## Summary
Fix critical bugs found in code review for scm-file and scm-message modules.

## Changes

### scm-file
- `FileMetadataService`: Removed redundant `.eq(deleted, 0)` since `@TableLogic` handles soft deletes automatically
- `ScmFileApplication`: Removed over-broad `@ComponentScan(basePackages = "com.scmcloud")` to avoid scanning other modules

### scm-message
- Event classes (`OrderCreatedEvent`, `InventoryChangedEvent`, `PriceChangedEvent`): Added `@AllArgsConstructor @NoArgsConstructor` annotations required by `@Builder`
- `OutboxPublisher`: Fixed `convertToDomainEvent` to deserialize payload from JSON instead of returning empty map (data loss bug)
- `OutboxService`: Renamed `save()` to `saveEvent()` to avoid shadowing parent `ServiceImpl.save()` method

## Related
Closes #162
