### PR TITLE
optimize: StatusMachineDubboService API and NPE fixes

### DIFF
--- a/scm-system/api/src/main/java/com/scmcloud/system/api/StatusMachineDubboService.java
+++ b/scm-system/api/src/main/java/com/scmcloud/system/api/StatusMachineDubboService.java
@@ -10,15 +10,26 @@ import java.util.List;
  */
 public interface StatusMachineDubboService {
 
+    // ─── Validation ────────────────────────────────────
+
     /**
-     * Check if a transition is allowed.
+     * Check if a transition from fromStatus to toStatus is allowed.
      */
     TransitionCheckDTO canTransition(String bizType, String fromStatus, String toStatus);
+
+    /**
+     * Check if a transition by actionCode is allowed from current status.
+     */
+    TransitionCheckDTO canTransitionByAction(String bizType, String fromStatus, String actionCode);
+
+    // ─── Execution ─────────────────────────────────────
 
     /**
      * Execute a transition by action code. Returns target status if valid.
      */
     TransitionResultDTO transition(String bizType, String fromStatus, String actionCode);
+
+    // ─── Query ─────────────────────────────────────────
 
     /**
      * Get all available actions from current status.

--- a/scm-system/service/src/main/java/com/scmcloud/system/dubbo/StatusMachineDubboServiceImpl.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/dubbo/StatusMachineDubboServiceImpl.java
@@ -23,6 +23,12 @@ public class StatusMachineDubboServiceImpl implements StatusMachineDubboService 
     }
 
     @Override
+    public TransitionCheckDTO canTransitionByAction(String bizType, String fromStatus, String actionCode) {
+        TransitionCheckResult r = stateMachineEngine.canTransitionByAction(bizType, fromStatus, actionCode);
+        return new TransitionCheckDTO(r.isAllowed(), r.getBizType(), r.getFromStatus(), r.getToStatus(), r.getReason());
+    }
+
+    @Override
     public TransitionResultDTO transition(String bizType, String fromStatus, String actionCode) {
         TransitionResult r = stateMachineEngine.transition(bizType, fromStatus, actionCode);
         return new TransitionResultDTO(r.isSuccess(), r.getBizType(), r.getFromStatus(), r.getToStatus(),

--- a/scm-system/service/src/main/java/com/scmcloud/system/statemachine/AvailableAction.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/statemachine/AvailableAction.java
@@ -1,7 +1,9 @@
 package com.scmcloud.system.statemachine;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * An available action from a given status.
@@ -9,6 +11,8 @@ import lombok.Data;
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AvailableAction {
 
     private String actionCode;

--- a/scm-system/service/src/main/java/com/scmcloud/system/statemachine/StateMachineEngine.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/statemachine/StateMachineEngine.java
@@ -10,8 +10,11 @@ import java.util.List;
  *
  * <p>Usage:</p>
  * <pre>
- * // Check if transition is valid
+ * // Check if transition is valid (by target status)
  * if (engine.canTransition("ORDER", "PAID", "SHIPPED").isAllowed()) { ... }
+ *
+ * // Check if transition is valid (by action code)
+ * if (engine.canTransitionByAction("ORDER", "PAID", "SHIP").isAllowed()) { ... }
  *
  * // Execute transition (validates + returns result)
  * TransitionResult result = engine.transition("ORDER", order.getStatus(), "SHIP");
@@ -26,6 +29,11 @@ public interface StateMachineEngine {
      * Check if a transition from fromStatus to toStatus is allowed.
      */
     TransitionCheckResult canTransition(String bizType, String fromStatus, String toStatus);
+
+    /**
+     * Check if a transition by actionCode is allowed from current status.
+     */
+    TransitionCheckResult canTransitionByAction(String bizType, String fromStatus, String actionCode);
 
     /**
      * Execute a transition by action code. Validates the transition is legal.

--- a/scm-system/service/src/main/java/com/scmcloud/system/statemachine/StateMachineEngineImpl.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/statemachine/StateMachineEngineImpl.java
@@ -5,6 +5,7 @@ import com.scmcloud.system.service.ISysStatusDictService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,10 +26,15 @@ public class StateMachineEngineImpl implements StateMachineEngine {
 
     @Override
     public TransitionCheckResult canTransition(String bizType, String fromStatus, String toStatus) {
+        if (!StringUtils.hasText(bizType) || !StringUtils.hasText(fromStatus) || !StringUtils.hasText(toStatus)) {
+            return TransitionCheckResult.deny(bizType, fromStatus, toStatus,
+                    "bizType, fromStatus, toStatus must not be blank");
+        }
+
         List<SysStatusTransition> transitions = statusDictService.listTransitionsFrom(bizType, fromStatus);
 
         boolean allowed = transitions.stream()
-                .anyMatch(t -> t.getToStatus().equals(toStatus) && t.getEnabled());
+                .anyMatch(t -> toStatus.equals(t.getToStatus()) && Boolean.TRUE.equals(t.getEnabled()));
 
         if (allowed) {
             return TransitionCheckResult.allow(bizType, fromStatus, toStatus);
@@ -39,11 +45,38 @@ public class StateMachineEngineImpl implements StateMachineEngine {
     }
 
     @Override
-    public TransitionResult transition(String bizType, String fromStatus, String actionCode) {
+    public TransitionCheckResult canTransitionByAction(String bizType, String fromStatus, String actionCode) {
+        if (!StringUtils.hasText(bizType) || !StringUtils.hasText(fromStatus) || !StringUtils.hasText(actionCode)) {
+            return TransitionCheckResult.deny(bizType, fromStatus, null,
+                    "bizType, fromStatus, actionCode must not be blank");
+        }
+
         List<SysStatusTransition> transitions = statusDictService.listTransitionsFrom(bizType, fromStatus);
 
         SysStatusTransition matched = transitions.stream()
-                .filter(t -> t.getActionCode().equals(actionCode) && t.getEnabled())
+                .filter(t -> actionCode.equals(t.getActionCode()) && Boolean.TRUE.equals(t.getEnabled()))
+                .findFirst()
+                .orElse(null);
+
+        if (matched != null) {
+            return TransitionCheckResult.allow(bizType, fromStatus, matched.getToStatus());
+        }
+
+        return TransitionCheckResult.deny(bizType, fromStatus, null,
+                "No enabled transition with action '" + actionCode + "' from status " + fromStatus + " for " + bizType);
+    }
+
+    @Override
+    public TransitionResult transition(String bizType, String fromStatus, String actionCode) {
+        if (!StringUtils.hasText(bizType) || !StringUtils.hasText(fromStatus) || !StringUtils.hasText(actionCode)) {
+            return TransitionResult.failure(bizType, fromStatus, actionCode,
+                    "bizType, fromStatus, actionCode must not be blank");
+        }
+
+        List<SysStatusTransition> transitions = statusDictService.listTransitionsFrom(bizType, fromStatus);
+
+        SysStatusTransition matched = transitions.stream()
+                .filter(t -> actionCode.equals(t.getActionCode()) && Boolean.TRUE.equals(t.getEnabled()))
                 .findFirst()
                 .orElse(null);
 
@@ -58,10 +91,14 @@ public class StateMachineEngineImpl implements StateMachineEngine {
 
     @Override
     public List<AvailableAction> getAvailableActions(String bizType, String currentStatus) {
+        if (!StringUtils.hasText(bizType) || !StringUtils.hasText(currentStatus)) {
+            return List.of();
+        }
+
         List<SysStatusTransition> transitions = statusDictService.listTransitionsFrom(bizType, currentStatus);
 
         return transitions.stream()
-                .filter(SysStatusTransition::getEnabled)
+                .filter(t -> Boolean.TRUE.equals(t.getEnabled()))
                 .map(t -> AvailableAction.builder()
                         .actionCode(t.getActionCode())
                         .actionName(t.getActionName())
@@ -75,10 +112,14 @@ public class StateMachineEngineImpl implements StateMachineEngine {
 
     @Override
     public List<String> getValidNextStatuses(String bizType, String currentStatus) {
+        if (!StringUtils.hasText(bizType) || !StringUtils.hasText(currentStatus)) {
+            return List.of();
+        }
+
         List<SysStatusTransition> transitions = statusDictService.listTransitionsFrom(bizType, currentStatus);
 
         return transitions.stream()
-                .filter(SysStatusTransition::getEnabled)
+                .filter(t -> Boolean.TRUE.equals(t.getEnabled()))
                 .map(SysStatusTransition::getToStatus)
                 .distinct()
                 .collect(Collectors.toList());

--- a/scm-system/service/src/main/java/com/scmcloud/system/statemachine/TransitionCheckResult.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/statemachine/TransitionCheckResult.java
@@ -1,13 +1,17 @@
 package com.scmcloud.system.statemachine;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Result of a transition eligibility check.
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TransitionCheckResult {
 
     private boolean allowed;

--- a/scm-system/service/src/main/java/com/scmcloud/system/statemachine/TransitionResult.java
+++ b/scm-system/service/src/main/java/com/scmcloud/system/statemachine/TransitionResult.java
@@ -1,14 +1,18 @@
 package com.scmcloud.system.statemachine;
 
 import com.scmcloud.system.domain.entity.SysStatusTransition;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 /**
  * Result of executing a state transition.
  */
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TransitionResult {
 
     private boolean success;


### PR DESCRIPTION
## Summary
Optimize StatusMachineDubboService API design and fix potential NPE issues in StateMachineEngineImpl.

## Changes

### API Enhancement
- Added `canTransitionByAction(bizType, fromStatus, actionCode)` method for checking transitions by action code
- Added section comments for better API organization (Validation / Execution / Query)

### NPE Fixes
- Changed `t.getToStatus().equals(toStatus)` to `toStatus.equals(t.getToStatus())` to avoid NPE
- Changed `t.getActionCode().equals(actionCode)` to `actionCode.equals(t.getActionCode())`
- Changed `t.getEnabled()` to `Boolean.TRUE.equals(t.getEnabled())` for safe Boolean unboxing

### Parameter Validation
- Added null/blank checks at the beginning of all StateMachineEngine methods
- Returns meaningful error messages instead of throwing exceptions

### Dubbo Compatibility
- Added `@NoArgsConstructor @AllArgsConstructor` to `TransitionCheckResult`, `TransitionResult`, `AvailableAction` for Dubbo deserialization

Closes #164
