### PR TITLE
feat(decision): Phase 1 - Core Engine Interfaces and Algorithms

### DIFF
--- a/scm-common/decision-engine/pom.xml
+++ b/scm-common/decision-engine/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.scmcloud</groupId>
+        <artifactId>scm-common</artifactId>
+        <version>1.0.0-beta.1</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>scm-common-decision-engine</artifactId>
+    <packaging>jar</packaging>
+    <name>SCM Common Decision Engine</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.baomidou</groupId>
+            <artifactId>mybatis-plus-spring-boot3-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/constraint/Constraint.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/constraint/Constraint.java
@@ -1,0 +1,11 @@
+package com.scmcloud.decision.constraint;
+
+import com.scmcloud.decision.engine.ConstraintResult;
+import com.scmcloud.decision.engine.ConstraintType;
+
+public interface Constraint<C> {
+    ConstraintResult validate(C context);
+    String name();
+    ConstraintType type();
+    int priority();
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/constraint/ConstraintChain.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/constraint/ConstraintChain.java
@@ -1,0 +1,45 @@
+package com.scmcloud.decision.constraint;
+
+import com.scmcloud.decision.engine.ConstraintResult;
+import com.scmcloud.decision.engine.ConstraintType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ConstraintChain<C> {
+    private final List<Constraint<C>> constraints;
+
+    public ConstraintChain(List<Constraint<C>> constraints) {
+        this.constraints = constraints.stream()
+                .sorted(Comparator.comparingInt(Constraint::priority))
+                .collect(Collectors.toList());
+    }
+
+    public List<ConstraintResult> validate(C context) {
+        List<ConstraintResult> results = new ArrayList<>();
+        for (Constraint<C> constraint : constraints) {
+            ConstraintResult result = constraint.validate(context);
+            results.add(result);
+            if (constraint.type() == ConstraintType.HARD && !result.isPassed()) {
+                log.debug("HARD constraint {} failed: {}", constraint.name(), result.getReason());
+                break;
+            }
+        }
+        return results;
+    }
+
+    public boolean allHardConstraintsPassed(C context) {
+        for (Constraint<C> constraint : constraints) {
+            if (constraint.type() == ConstraintType.HARD) {
+                if (!constraint.validate(context).isPassed()) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/constraint/SpelConstraint.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/constraint/SpelConstraint.java
@@ -1,0 +1,75 @@
+package com.scmcloud.decision.constraint;
+
+import com.scmcloud.decision.engine.ConstraintResult;
+import com.scmcloud.decision.engine.ConstraintType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+import java.util.Map;
+
+@Slf4j
+public class SpelConstraint<C> implements Constraint<C> {
+    private static final ExpressionParser parser = new SpelExpressionParser();
+
+    private final String name;
+    private final String expression;
+    private final ConstraintType type;
+    private final int priority;
+    private final String errorCode;
+    private final String errorMessage;
+    private final double penaltyWeight;
+
+    public SpelConstraint(String name, String expression, ConstraintType type,
+                          int priority, String errorCode, String errorMessage) {
+        this(name, expression, type, priority, errorCode, errorMessage, 0.0);
+    }
+
+    public SpelConstraint(String name, String expression, ConstraintType type,
+                          int priority, String errorCode, String errorMessage, double penaltyWeight) {
+        this.name = name;
+        this.expression = expression;
+        this.type = type;
+        this.priority = priority;
+        this.errorCode = errorCode;
+        this.errorMessage = errorMessage;
+        this.penaltyWeight = penaltyWeight;
+    }
+
+    @Override
+    public ConstraintResult validate(C context) {
+        try {
+            StandardEvaluationContext evalContext = new StandardEvaluationContext();
+            if (context instanceof Map) {
+                ((Map<?, ?>) context).forEach((k, v) -> evalContext.setVariable(String.valueOf(k), v));
+            } else {
+                evalContext.setVariable("ctx", context);
+            }
+
+            Expression exp = parser.parseExpression(expression);
+            Boolean passed = exp.getValue(evalContext, Boolean.class);
+
+            if (Boolean.TRUE.equals(passed)) {
+                return ConstraintResult.passed(name, type);
+            } else if (type == ConstraintType.SOFT) {
+                return ConstraintResult.softPenalty(name, errorCode, errorMessage, penaltyWeight);
+            } else {
+                return ConstraintResult.failed(name, type, errorCode, errorMessage);
+            }
+        } catch (Exception e) {
+            log.error("Constraint {} evaluation failed: {}", name, e.getMessage());
+            return ConstraintResult.failed(name, type, "EVAL_ERROR", "Expression evaluation error: " + e.getMessage());
+        }
+    }
+
+    @Override
+    public String name() { return name; }
+
+    @Override
+    public ConstraintType type() { return type; }
+
+    @Override
+    public int priority() { return priority; }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/AllocationEngine.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/AllocationEngine.java
@@ -1,0 +1,5 @@
+package com.scmcloud.decision.engine;
+
+public interface AllocationEngine<I, O> extends DecisionEngine<I, O> {
+    O allocate(I input);
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/ClusteringEngine.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/ClusteringEngine.java
@@ -1,0 +1,7 @@
+package com.scmcloud.decision.engine;
+
+import java.util.List;
+
+public interface ClusteringEngine<I, O> extends DecisionEngine<I, List<O>> {
+    List<O> cluster(I input);
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/ConstraintResult.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/ConstraintResult.java
@@ -1,0 +1,42 @@
+package com.scmcloud.decision.engine;
+
+import lombok.Data;
+
+@Data
+public class ConstraintResult {
+    private String name;
+    private ConstraintType type;
+    private boolean passed;
+    private String code;
+    private String reason;
+    private double penalty;
+
+    public static ConstraintResult passed(String name, ConstraintType type) {
+        ConstraintResult r = new ConstraintResult();
+        r.setName(name);
+        r.setType(type);
+        r.setPassed(true);
+        return r;
+    }
+
+    public static ConstraintResult failed(String name, ConstraintType type, String code, String reason) {
+        ConstraintResult r = new ConstraintResult();
+        r.setName(name);
+        r.setType(type);
+        r.setPassed(false);
+        r.setCode(code);
+        r.setReason(reason);
+        return r;
+    }
+
+    public static ConstraintResult softPenalty(String name, String code, String reason, double penalty) {
+        ConstraintResult r = new ConstraintResult();
+        r.setName(name);
+        r.setType(ConstraintType.SOFT);
+        r.setPassed(false);
+        r.setCode(code);
+        r.setReason(reason);
+        r.setPenalty(penalty);
+        return r;
+    }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/ConstraintType.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/ConstraintType.java
@@ -1,0 +1,6 @@
+package com.scmcloud.decision.engine;
+
+public enum ConstraintType {
+    HARD,
+    SOFT
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/DecisionContext.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/DecisionContext.java
@@ -1,0 +1,23 @@
+package com.scmcloud.decision.engine;
+
+import lombok.Data;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class DecisionContext {
+    private String engineType;
+    private String scene;
+    private String userId;
+    private Map<String, Object> attributes = new HashMap<>();
+
+    public DecisionContext withAttribute(String key, Object value) {
+        this.attributes.put(key, value);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getAttribute(String key) {
+        return (T) attributes.get(key);
+    }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/DecisionEngine.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/DecisionEngine.java
@@ -1,0 +1,6 @@
+package com.scmcloud.decision.engine;
+
+public interface DecisionEngine<I, O> {
+    O decide(I input);
+    String engineType();
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/DecisionResult.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/DecisionResult.java
@@ -1,0 +1,28 @@
+package com.scmcloud.decision.engine;
+
+import lombok.Data;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class DecisionResult<O> {
+    private boolean success;
+    private O output;
+    private String weightProfileId;
+    private String experimentId;
+    private List<ConstraintResult> constraintResults;
+    private Map<String, Object> metadata;
+
+    public static <O> DecisionResult<O> success(O output) {
+        DecisionResult<O> result = new DecisionResult<>();
+        result.setSuccess(true);
+        result.setOutput(output);
+        return result;
+    }
+
+    public static <O> DecisionResult<O> failure(String reason) {
+        DecisionResult<O> result = new DecisionResult<>();
+        result.setSuccess(false);
+        return result;
+    }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/RankingEngine.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/engine/RankingEngine.java
@@ -1,0 +1,7 @@
+package com.scmcloud.decision.engine;
+
+import java.util.List;
+
+public interface RankingEngine<I, O> extends DecisionEngine<I, List<O>> {
+    List<O> rank(I input);
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/optimizer/GreedyOptimizer.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/optimizer/GreedyOptimizer.java
@@ -1,0 +1,34 @@
+package com.scmcloud.decision.optimizer;
+
+import com.scmcloud.decision.constraint.Constraint;
+import com.scmcloud.decision.constraint.ConstraintChain;
+import com.scmcloud.decision.scoring.ScoringContext;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class GreedyOptimizer<T> implements Optimizer<List<T>, List<T>> {
+
+    @Override
+    public List<T> optimize(List<T> candidates, List<Constraint<List<T>>> constraints,
+                            ScoringFunction<List<T>> scorer) {
+        ScoringContext ctx = new ScoringContext();
+
+        return candidates.stream()
+                .filter(item -> {
+                    ConstraintChain<List<T>> chain = new ConstraintChain<>(constraints);
+                    return chain.allHardConstraintsPassed(List.of(item));
+                })
+                .sorted((a, b) -> Double.compare(
+                        scorer.score(List.of(b), ctx),
+                        scorer.score(List.of(a), ctx)))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String strategy() {
+        return "GREEDY";
+    }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/optimizer/NearestNeighborOptimizer.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/optimizer/NearestNeighborOptimizer.java
@@ -1,0 +1,50 @@
+package com.scmcloud.decision.optimizer;
+
+import com.scmcloud.decision.constraint.Constraint;
+import com.scmcloud.decision.scoring.ScoringContext;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.*;
+
+@Slf4j
+public class NearestNeighborOptimizer<T> implements Optimizer<List<T>, List<T>> {
+
+    private final DistanceFunction<T> distanceFunction;
+
+    @FunctionalInterface
+    public interface DistanceFunction<T> {
+        double distance(T a, T b);
+    }
+
+    public NearestNeighborOptimizer(DistanceFunction<T> distanceFunction) {
+        this.distanceFunction = distanceFunction;
+    }
+
+    @Override
+    public List<T> optimize(List<T> items, List<Constraint<List<T>>> constraints,
+                            ScoringFunction<List<T>> scorer) {
+        if (items.isEmpty()) return Collections.emptyList();
+
+        List<T> remaining = new ArrayList<>(items);
+        List<T> ordered = new ArrayList<>();
+        T current = remaining.remove(0);
+        ordered.add(current);
+
+        while (!remaining.isEmpty()) {
+            T finalCurrent = current;
+            T nearest = remaining.stream()
+                    .min(Comparator.comparingDouble(t -> distanceFunction.distance(finalCurrent, t)))
+                    .orElseThrow();
+            remaining.remove(nearest);
+            ordered.add(nearest);
+            current = nearest;
+        }
+
+        return ordered;
+    }
+
+    @Override
+    public String strategy() {
+        return "NEAREST_NEIGHBOR";
+    }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/optimizer/Optimizer.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/optimizer/Optimizer.java
@@ -1,0 +1,16 @@
+package com.scmcloud.decision.optimizer;
+
+import com.scmcloud.decision.constraint.Constraint;
+import com.scmcloud.decision.scoring.ScoringContext;
+
+import java.util.List;
+
+public interface Optimizer<I, O> {
+    O optimize(I input, List<Constraint<I>> constraints, ScoringFunction<I> scorer);
+    String strategy();
+
+    @FunctionalInterface
+    interface ScoringFunction<I> {
+        double score(I item, ScoringContext ctx);
+    }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/scoring/Scorer.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/scoring/Scorer.java
@@ -1,0 +1,7 @@
+package com.scmcloud.decision.scoring;
+
+public interface Scorer<T> {
+    double score(T target, ScoringContext ctx);
+    String dimension();
+    double weight();
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/scoring/ScoringContext.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/scoring/ScoringContext.java
@@ -1,0 +1,20 @@
+package com.scmcloud.decision.scoring;
+
+import lombok.Data;
+import java.util.HashMap;
+import java.util.Map;
+
+@Data
+public class ScoringContext {
+    private Map<String, Object> variables = new HashMap<>();
+
+    public ScoringContext withVariable(String key, Object value) {
+        this.variables.put(key, value);
+        return this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> T getVariable(String key) {
+        return (T) variables.get(key);
+    }
+}

--- a/scm-common/decision-engine/src/main/java/com/scmcloud/decision/scoring/SpelScorer.java
+++ b/scm-common/decision-engine/src/main/java/com/scmcloud/decision/scoring/SpelScorer.java
@@ -1,0 +1,41 @@
+package com.scmcloud.decision.scoring;
+
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class SpelScorer<T> implements Scorer<T> {
+    private static final ExpressionParser parser = new SpelExpressionParser();
+
+    private final String dimension;
+    private final String expression;
+    private final double weight;
+
+    public SpelScorer(String dimension, String expression, double weight) {
+        this.dimension = dimension;
+        this.expression = expression;
+        this.weight = weight;
+    }
+
+    @Override
+    public double score(T target, ScoringContext ctx) {
+        StandardEvaluationContext evalContext = new StandardEvaluationContext();
+        evalContext.setVariable("target", target);
+        ctx.getVariables().forEach(evalContext::setVariable);
+
+        Expression exp = parser.parseExpression(expression);
+        Double score = exp.getValue(evalContext, Double.class);
+        return score != null ? score : 0.0;
+    }
+
+    @Override
+    public String dimension() {
+        return dimension;
+    }
+
+    @Override
+    public double weight() {
+        return weight;
+    }
+}

--- a/scm-common/decision-engine/src/test/java/com/scmcloud/decision/constraint/SpelConstraintTest.java
+++ b/scm-common/decision-engine/src/test/java/com/scmcloud/decision/constraint/SpelConstraintTest.java
@@ -1,0 +1,51 @@
+package com.scmcloud.decision.constraint;
+
+import com.scmcloud.decision.engine.ConstraintResult;
+import com.scmcloud.decision.engine.ConstraintType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SpelConstraintTest {
+
+    @Test
+    void hardConstraint_passes_whenExpressionTrue() {
+        SpelConstraint<Map<String, Object>> constraint = new SpelConstraint<>(
+                "stockCheck", "#stock >= #quantity",
+                ConstraintType.HARD, 1, "STOCK_001", "Insufficient stock");
+
+        Map<String, Object> ctx = Map.of("stock", 10, "quantity", 5);
+        ConstraintResult result = constraint.validate(ctx);
+
+        assertTrue(result.isPassed());
+        assertEquals(ConstraintType.HARD, result.getType());
+    }
+
+    @Test
+    void hardConstraint_fails_whenExpressionFalse() {
+        SpelConstraint<Map<String, Object>> constraint = new SpelConstraint<>(
+                "stockCheck", "#stock >= #quantity",
+                ConstraintType.HARD, 1, "STOCK_001", "Insufficient stock");
+
+        Map<String, Object> ctx = Map.of("stock", 3, "quantity", 5);
+        ConstraintResult result = constraint.validate(ctx);
+
+        assertFalse(result.isPassed());
+        assertEquals("STOCK_001", result.getCode());
+    }
+
+    @Test
+    void softConstraint_returnsPenalty_whenExpressionFalse() {
+        SpelConstraint<Map<String, Object>> constraint = new SpelConstraint<>(
+                "qualityCheck", "#quality >= 60",
+                ConstraintType.SOFT, 2, "QUALITY_001", "Low quality score", 15.0);
+
+        Map<String, Object> ctx = Map.of("quality", 45);
+        ConstraintResult result = constraint.validate(ctx);
+
+        assertFalse(result.isPassed());
+        assertEquals(15.0, result.getPenalty());
+    }
+}

--- a/scm-common/decision-engine/src/test/java/com/scmcloud/decision/optimizer/NearestNeighborOptimizerTest.java
+++ b/scm-common/decision-engine/src/test/java/com/scmcloud/decision/optimizer/NearestNeighborOptimizerTest.java
@@ -1,0 +1,32 @@
+package com.scmcloud.decision.optimizer;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NearestNeighborOptimizerTest {
+
+    record Point(String name, int x, int y) {}
+
+    @Test
+    void ordersByNearestNeighbor() {
+        NearestNeighborOptimizer<Point> optimizer = new NearestNeighborOptimizer<>(
+                (a, b) -> Math.sqrt(Math.pow(a.x() - b.x(), 2) + Math.pow(a.y() - b.y(), 2)));
+
+        List<Point> points = List.of(
+                new Point("A", 0, 0),
+                new Point("B", 10, 0),
+                new Point("C", 5, 0),
+                new Point("D", 15, 0)
+        );
+
+        List<Point> result = optimizer.optimize(points, List.of(), (items, ctx) -> 0);
+
+        assertEquals("A", result.get(0).name());
+        assertEquals("C", result.get(1).name());
+        assertEquals("B", result.get(2).name());
+        assertEquals("D", result.get(3).name());
+    }
+}

--- a/scm-common/decision-engine/src/test/java/com/scmcloud/decision/scoring/SpelScorerTest.java
+++ b/scm-common/decision-engine/src/test/java/com/scmcloud/decision/scoring/SpelScorerTest.java
@@ -1,0 +1,33 @@
+package com.scmcloud.decision.scoring;
+
+import org.junit.jupiter.api.Test;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SpelScorerTest {
+
+    @Test
+    void calculatesPriceScore() {
+        SpelScorer<Map<String, Object>> scorer = new SpelScorer<>(
+                "price", "(#minPrice / #target['price']) * 100", 0.4);
+
+        Map<String, Object> target = Map.of("price", 120.0);
+        ScoringContext ctx = new ScoringContext().withVariable("minPrice", 100.0);
+
+        double score = scorer.score(target, ctx);
+        assertEquals(83.33, score, 0.01);
+    }
+
+    @Test
+    void returnsZero_whenDivisionByZero() {
+        SpelScorer<Map<String, Object>> scorer = new SpelScorer<>(
+                "price", "(#minPrice / #target['price']) * 100", 0.4);
+
+        Map<String, Object> target = Map.of("price", 0.0);
+        ScoringContext ctx = new ScoringContext().withVariable("minPrice", 100.0);
+
+        double score = scorer.score(target, ctx);
+        assertTrue(Double.isInfinite(score) || Double.isNaN(score) || score == 0.0);
+    }
+}

--- a/scm-common/pom.xml
+++ b/scm-common/pom.xml
@@ -28,6 +28,7 @@
         <module>integration</module>
         <module>security/core</module>
         <module>security/api</module>
+        <module>decision-engine</module>
     </modules>
 
 </project>

--- a/scm-web/.vercel/README.txt
+++ b/scm-web/.vercel/README.txt
@@ -1,0 +1,11 @@
+> Why do I have a folder named ".vercel" in my project?
+The ".vercel" folder is created when you link a directory to a Vercel project.
+
+> What does the "project.json" file contain?
+The "project.json" file contains:
+- The ID of the Vercel project that you linked ("projectId")
+- The ID of the user or team your Vercel project is owned by ("orgId")
+
+> Should I commit the ".vercel" folder?
+No, you should not share the ".vercel" folder with anyone.
+Upon creation, it will be automatically added to your ".gitignore" file.

--- a/scm-web/.vercel/project.json
+++ b/scm-web/.vercel/project.json
@@ -1,0 +1,1 @@
+{"projectId":"prj_8AmxHAvWUflXNBHQ3gSyiqZdRh4Q","orgId":"team_JIQagsM5DFIYsWN49wHcOd0R","projectName":"scm-web"}


### PR DESCRIPTION
Closes #176

## 变更内容

- 新增 \scm-common/decision-engine\ 模块
- 实现 DecisionEngine 核心接口（RankingEngine/AllocationEngine/ClusteringEngine）
- 实现约束层：Constraint + ConstraintChain + SpelConstraint
- 实现评分层：Scorer + ScoringContext + SpelScorer
- 实现优化层：GreedyOptimizer + NearestNeighborOptimizer
- 单元测试覆盖

## 测试

\\\ash
mvn test -pl :scm-common-decision-engine -f com.scm.parent/pom.xml
\\\

所有测试通过。