### PR TITLE
config: 调整 Auth 服务 Sentinel 限流阈值

### DIFF
--- a/scm-auth/src/main/resources/auth-service-sentinel-degrade.json
+++ b/scm-auth/src/main/resources/auth-service-sentinel-degrade.json
@@ -2,7 +2,7 @@
   {
     "resource": "userService",
     "grade": 0,
-    "count": 1000,
+    "count": 300,
     "timeWindow": 10,
     "minRequestAmount": 5,
     "statIntervalMs": 1000,


### PR DESCRIPTION
## Summary

- 将 Auth 服务 Sentinel 限流阈值从 1000 降低到 300
- 提供更严格的流量保护

Closes #228