### PR TITLE
fix(system): add missing commons-lang3 dependency

### DIFF
--- a/scm-system/service/pom.xml
+++ b/scm-system/service/pom.xml
@@ -81,6 +81,13 @@
             <artifactId>flyway-database-postgresql</artifactId>
         </dependency>
 
+        <!-- Apache Commons -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+
         <!-- spring start -->
         <dependency>
             <groupId>org.springframework</groupId>


### PR DESCRIPTION
## Summary

scm-system/service/ShardingUserService.java 使用 org.apache.commons.lang3.StringUtils 但 scm-system/service/pom.xml 缺少 commons-lang3 依赖，导致整个项目无法编译。

## 问题

\\\
ERROR scm-system/service/src/main/java/com/scmcloud/system/sharding/service/ShardingUserService.java:[8,32] 找不到符号 org.apache.commons.lang3
\\\

## 解决方案

在 scm-system/service/pom.xml 中添加 commons-lang3 依赖。

## 历史背景

该依赖曾在 commit 4d2bde0 中添加，但在 origin/feat/lua-script-center 强制重置时丢失。该 commit 在本地 feat/lua-script-center 仍存在但未推送到 origin。

## 影响

此修复是后续所有 PR 能够通过 CI 的前提（mvn compile 必须成功）。当前阻塞 PR #237 (SysUserService CQRS) 等。